### PR TITLE
Prevent Project Information section from shrinking on window resize

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,6 +73,7 @@
 
   /* PROJECT BOM VIEW */
   #pbv{flex:1;overflow-y:auto;display:none;flex-direction:column;background:var(--forti-content-bg);padding:20px;gap:14px;}
+  #pbv > *{flex-shrink:0;}
   #pbv::-webkit-scrollbar{width:6px;}
   #pbv::-webkit-scrollbar-thumb{background:#C8CDD9;border-radius:3px;}
 


### PR DESCRIPTION
Direct children of #pbv had default flex-shrink:1, causing the Project Information card to compress when BOM content exceeded the viewport height. Setting flex-shrink:0 on all direct children ensures the container scrolls instead of squishing the section.

https://claude.ai/code/session_01RwY7cVqvro57NDyueifYoy