### PR TITLE
Add responsive mobile sidebar with hamburger toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,6 +184,22 @@
   #toast{position:fixed;bottom:24px;right:24px;z-index:999;background:#2A2F3A;color:#E8EAF0;font-size:12px;padding:10px 16px;border-radius:4px;border-left:3px solid var(--forti-red);opacity:0;transform:translateY(8px);transition:opacity .2s,transform .2s;pointer-events:none;max-width:340px;}
   #toast.on{opacity:1;transform:translateY(0);}
 
+  /* Hamburger menu button (mobile only) */
+  #menu-btn{display:none;align-items:center;justify-content:center;background:none;border:none;cursor:pointer;padding:4px 6px;color:var(--forti-text-secondary);flex-shrink:0;border-radius:3px;}
+  #menu-btn:hover{color:var(--forti-text-primary);background:rgba(255,255,255,.06);}
+  #menu-btn svg{display:block;}
+
+  /* Sidebar backdrop overlay (mobile) */
+  #sidebar-overlay{display:none;position:fixed;inset:0;z-index:90;background:rgba(0,0,0,.45);}
+  #sidebar-overlay.on{display:block;}
+
+  /* Mobile responsive sidebar */
+  @media (max-width:768px) {
+    #menu-btn{display:flex;}
+    #sidebar{position:fixed;top:var(--hh);left:0;bottom:0;z-index:100;transform:translateX(-100%);transition:transform .25s ease;}
+    #sidebar.open{transform:translateX(0);box-shadow:4px 0 24px rgba(0,0,0,.45);}
+  }
+
   /* Print */
   @media print {
     body{background:#fff;overflow:auto;height:auto;}
@@ -198,6 +214,9 @@
 <body>
 
 <div id="top-bar">
+  <button id="menu-btn" onclick="toggleSidebar()" title="Toggle navigation" aria-label="Toggle navigation">
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none"><path d="M3 5h12M3 9h12M3 13h12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
+  </button>
   <div class="logo-wrap">
     <svg class="logo-icon" viewBox="0 0 28 28" fill="none"><rect width="28" height="28" rx="4" fill="#EE3124"/><path d="M6 8h16v3H6zM6 12.5h10v3H6zM6 17h16v3H6z" fill="white"/></svg>
     <span class="product-name"><span>Forti</span>BOM</span>
@@ -213,6 +232,7 @@
   <span class="ver-badge">v2.0</span>
 </div>
 
+<div id="sidebar-overlay" onclick="closeSidebar()"></div>
 <div id="main">
   <nav id="sidebar">
     <div class="nsl" style="padding-bottom:4px;">Project</div>
@@ -435,11 +455,24 @@ async function buildNav() {
 }
 async function exists(path) { try { return (await fetch(path,{method:'HEAD'})).ok; } catch { return false; } }
 
+// ── MOBILE SIDEBAR TOGGLE ─────────────────────────────────────────────────────
+function toggleSidebar() {
+  const s = document.getElementById('sidebar');
+  const o = document.getElementById('sidebar-overlay');
+  const open = s.classList.toggle('open');
+  open ? o.classList.add('on') : o.classList.remove('on');
+}
+function closeSidebar() {
+  document.getElementById('sidebar').classList.remove('open');
+  document.getElementById('sidebar-overlay').classList.remove('on');
+}
+
 // ── NAVIGATION ───────────────────────────────────────────────────────────────
 function setActiveNav(el) {
   document.querySelectorAll('.ni').forEach(n=>n.classList.remove('active'));
   if (el) el.classList.add('active');
   activeNav = el;
+  closeSidebar();
 }
 function loadProduct(path, label, navEl) {
   setActiveNav(navEl);


### PR DESCRIPTION
Below 768px the sidebar hides off-screen; a hamburger button in the top bar slides it in. Tapping the backdrop or selecting a nav item closes it automatically.

https://claude.ai/code/session_01MHtt2pXjpaUP127cZ1sgWK