### PR TITLE
Align BOM table columns across product groups with table-layout: fixed

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,7 +118,7 @@
   .bg-del:hover{background:#F5C6C2;}
 
   /* BOM table */
-  table.bt{width:100%;border-collapse:collapse;font-size:12px;}
+  table.bt{width:100%;border-collapse:collapse;font-size:12px;table-layout:fixed;}
   table.bt thead th{background:var(--c-th);border:1px solid var(--c-border);padding:6px 10px;text-align:left;font-weight:700;font-size:10px;text-transform:uppercase;letter-spacing:.05em;color:#4A5268;white-space:nowrap;}
   table.bt tbody td{border:1px solid var(--c-border);padding:6px 10px;vertical-align:top;font-size:12px;}
   table.bt tbody tr:nth-child(even) td{background:var(--c-sh);}


### PR DESCRIPTION
Adds table-layout:fixed to .bt so all group tables honor the same
<th> widths rather than independently sizing columns to fit content.

https://claude.ai/code/session_01Fy2aync7jFSrQqXGNhRigy