### PR TITLE
Fix mobile table layout: enable horizontal scrolling in Project BOM

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,7 +118,8 @@
   .bg-del:hover{background:#F5C6C2;}
 
   /* BOM table */
-  table.bt{width:100%;border-collapse:collapse;font-size:12px;table-layout:fixed;}
+  .bt-wrap{overflow-x:auto;-webkit-overflow-scrolling:touch;}
+  table.bt{width:100%;border-collapse:collapse;font-size:12px;table-layout:fixed;min-width:580px;}
   table.bt thead th{background:var(--c-th);border:1px solid var(--c-border);padding:6px 10px;text-align:left;font-weight:700;font-size:10px;text-transform:uppercase;letter-spacing:.05em;color:#4A5268;white-space:nowrap;}
   table.bt tbody td{border:1px solid var(--c-border);padding:6px 10px;vertical-align:top;font-size:12px;}
   table.bt tbody tr:nth-child(even) td{background:var(--c-sh);}
@@ -592,10 +593,10 @@ function renderGroups() {
           <span class="bg-tag">${h(entry.product)}</span>
           <button class="bg-del" onclick="removeFromCart(${entry.id})">✕ Remove</button>
         </div>
-        <table class="bt"><thead><tr>
+        <div class="bt-wrap"><table class="bt"><thead><tr>
           <th style="width:200px;">Part Number</th><th>Description</th>
           <th style="width:50px;text-align:center;">Qty</th><th style="width:80px;">Type</th><th>Notes</th>
-        </tr></thead><tbody>${rows}</tbody></table>`;
+        </tr></thead><tbody>${rows}</tbody></table></div>`;
       addDragListeners(el);
       c.appendChild(el);
     }


### PR DESCRIPTION
Wrap BOM tables in a scrollable div (.bt-wrap) and set a min-width of
580px so columns render at a readable size on mobile instead of
squishing and overlapping. Users can now scroll left/right to see all
columns.

https://claude.ai/code/session_017crqTex8mgmScq6bBXEb19