### PR TITLE
Normalize SKU term suffix to -DD on import

### DIFF
--- a/index.html
+++ b/index.html
@@ -873,7 +873,9 @@ function parseCSV(text) {
     }
     if (currentEntry && sku) {
       const qn = qty !== '' ? (isNaN(Number(qty)) ? qty : Number(qty)) : undefined;
-      currentEntry.rows.push({ sku, desc, qty:qn, kind, note });
+      // Normalize SKU back to -DD so term substitution works after import
+      const normSku = meta.term !== 'DD' ? sku.replace(new RegExp(`-${meta.term}$`, 'i'), '-DD') : sku;
+      currentEntry.rows.push({ sku: normSku, desc, qty:qn, kind, note });
     }
   }
   const prodCount = items.filter(i=>!i._type).length;


### PR DESCRIPTION
## Summary
This change normalizes SKU term suffixes back to the standard `-DD` format during import, ensuring that term substitution works correctly after data is imported.

## Key Changes
- Added SKU normalization logic that converts term-specific suffixes (e.g., `-ABC`) back to the standard `-DD` suffix
- The normalization only applies when the current term metadata differs from `DD`
- Uses a case-insensitive regex pattern to match and replace the term suffix at the end of the SKU

## Implementation Details
- The normalization occurs before pushing the row entry to maintain consistency with the expected SKU format
- The regex pattern `new RegExp(`-${meta.term}$`, 'i')` dynamically matches the current term suffix and replaces it with `-DD`
- This ensures that imported items with term-specific SKUs are converted to the canonical format for proper term substitution handling

https://claude.ai/code/session_015YPPCGaKNLWYN9bybNYf1x