### PR TITLE
Align delete button to the right with margin-left auto

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
   .bgp{font-size:12px;font-weight:700;color:var(--c-text);flex:1;}
   .bgm{font-size:11px;color:var(--c-text2);}
   .bg-tag{font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:.05em;background:#EEF3FF;color:#3557A5;border:1px solid #B8CBF5;border-radius:2px;padding:1px 6px;}
-  .bg-del{background:#FEF0EE;border:1px solid #F5C6C2;color:#C0392B;font-size:11px;font-weight:600;padding:3px 8px;border-radius:2px;cursor:pointer;font-family:inherit;}
+  .bg-del{background:#FEF0EE;border:1px solid #F5C6C2;color:#C0392B;font-size:11px;font-weight:600;padding:3px 8px;border-radius:2px;cursor:pointer;font-family:inherit;margin-left:auto;}
   .bg-del:hover{background:#F5C6C2;}
 
   /* BOM table */


### PR DESCRIPTION
## Summary
Updated the `.bg-del` button styling to align it to the right side of its container using `margin-left: auto`.

## Changes
- Added `margin-left: auto;` to the `.bg-del` CSS class to push the delete button to the right edge of its flex container

## Details
This change improves the layout of delete buttons by automatically pushing them to the right side of their parent container, assuming the parent uses flexbox layout. This is a common pattern for action buttons that should be visually separated from other content.

https://claude.ai/code/session_01WgHHatjNiqUkYqHrtwN1bL