### PR TITLE
Add Copy/Export dropdown menu with multiple format options

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,6 +201,15 @@
     #sidebar.open{transform:translateX(0);box-shadow:4px 0 24px rgba(0,0,0,.45);}
   }
 
+  /* Copy/Export dropdown menu */
+  #copy-menu{display:none;position:fixed;background:#fff;border:1px solid var(--c-border);border-radius:4px;box-shadow:0 6px 20px rgba(0,0,0,.15);min-width:196px;z-index:600;overflow:hidden;padding:4px 0;}
+  #copy-menu.on{display:block;}
+  .dm-section{font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:.09em;color:var(--c-textm);padding:6px 12px 2px;}
+  .dm-item{display:flex;align-items:center;gap:8px;padding:7px 12px;font-size:12px;color:var(--c-text);cursor:pointer;white-space:nowrap;font-family:inherit;background:none;border:none;width:100%;text-align:left;}
+  .dm-item:hover{background:var(--c-sh);}
+  .dm-item svg{width:13px;height:13px;flex-shrink:0;color:var(--c-text2);}
+  .dm-sep{height:1px;background:var(--c-border);margin:3px 0;}
+
   /* Print */
   @media print {
     body{background:#fff;overflow:auto;height:auto;}
@@ -311,7 +320,7 @@
           <button class="btn bs" onclick="openImport()"><svg viewBox="0 0 13 13" fill="none"><path d="M6.5 9V1M9.5 6l-3 3-3-3" stroke="#6B7589" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/><path d="M1 10v1a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1v-1" stroke="#6B7589" stroke-width="1.3" stroke-linecap="round"/></svg>Import CSV</button>
           <button class="btn bs" onclick="openAddGroup()"><svg viewBox="0 0 13 13" fill="none"><rect x="1" y="4" width="11" height="5" rx="1" stroke="#6B7589" stroke-width="1.1"/><path d="M4 6.5h5M6.5 5.5v2" stroke="#6B7589" stroke-width="1.1" stroke-linecap="round"/></svg>Add Group</button>
           <button class="btn bs" onclick="window.print()"><svg viewBox="0 0 13 13" fill="none"><rect x="1.5" y="4" width="10" height="6" rx="1" stroke="#6B7589" stroke-width="1.1"/><path d="M3.5 4V2h6v2M3.5 10h6" stroke="#6B7589" stroke-width="1.1" stroke-linecap="round"/></svg>Print</button>
-          <button class="btn bs" onclick="copyTSV()"><svg viewBox="0 0 13 13" fill="none"><rect x="3.5" y="1" width="8" height="9" rx="1" stroke="#6B7589" stroke-width="1.1"/><rect x="1" y="3" width="8" height="9" rx="1" stroke="#6B7589" stroke-width="1.1"/></svg>Copy TSV</button>
+          <button class="btn bs" id="copy-export-btn" onclick="toggleCopyMenu(event)"><svg viewBox="0 0 13 13" fill="none"><rect x="3.5" y="1" width="8" height="9" rx="1" stroke="#6B7589" stroke-width="1.1"/><rect x="1" y="3" width="8" height="9" rx="1" stroke="#6B7589" stroke-width="1.1"/></svg>Copy / Export<svg viewBox="0 0 10 6" fill="none" style="width:9px;height:9px;margin-left:1px;"><path d="M1 1l4 4 4-4" stroke="#6B7589" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
           <button class="btn bd" onclick="clearCart()"><svg viewBox="0 0 13 13" fill="none"><path d="M2 3.5h9M5 3.5V2h3v1.5M5.5 6v4M7.5 6v4" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/><path d="M3 3.5l.5 7a1 1 0 0 0 1 .9h4a1 1 0 0 0 1-.9l.5-7" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/></svg>Clear All</button>
         </div>
       </div>
@@ -331,6 +340,19 @@
 </div>
 
 <div id="toast"></div>
+
+<!-- Copy/Export dropdown menu (position:fixed so it escapes overflow-y:auto parents) -->
+<div id="copy-menu">
+  <div class="dm-section">Copy to Clipboard</div>
+  <button class="dm-item" onclick="copyTSV()"><svg viewBox="0 0 13 13" fill="none"><rect x="3.5" y="1" width="8" height="9" rx="1" stroke="currentColor" stroke-width="1.1"/><rect x="1" y="3" width="8" height="9" rx="1" stroke="currentColor" stroke-width="1.1"/></svg>Copy TSV</button>
+  <button class="dm-item" onclick="copyBOMCSV()"><svg viewBox="0 0 13 13" fill="none"><rect x="1" y="1" width="11" height="11" rx="1" stroke="currentColor" stroke-width="1.1"/><path d="M1 4.5h11M4.5 4.5v7" stroke="currentColor" stroke-width="1.1"/></svg>Copy CSV</button>
+  <button class="dm-item" onclick="copyMD()"><svg viewBox="0 0 13 13" fill="none"><rect x="1" y="2.5" width="11" height="8" rx="1" stroke="currentColor" stroke-width="1.1"/><path d="M3.5 8.5V4.5l2 2.5 2-2.5v4M9.5 8.5V4.5l-1.5 2" stroke="currentColor" stroke-width="1.1" stroke-linecap="round" stroke-linejoin="round"/></svg>Copy Markdown</button>
+  <div class="dm-sep"></div>
+  <div class="dm-section">SFDC Export (Download CSV)</div>
+  <button class="dm-item" onclick="exportSFDC('AMER')"><svg viewBox="0 0 13 13" fill="none"><path d="M6.5 1v8M3.5 6l3 3 3-3" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/><path d="M1 10v1a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1v-1" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/></svg>Export SFDC-AMER</button>
+  <button class="dm-item" onclick="exportSFDC('EMEA')"><svg viewBox="0 0 13 13" fill="none"><path d="M6.5 1v8M3.5 6l3 3 3-3" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/><path d="M1 10v1a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1v-1" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/></svg>Export SFDC-EMEA</button>
+  <button class="dm-item" onclick="exportSFDC('APAC')"><svg viewBox="0 0 13 13" fill="none"><path d="M6.5 1v8M3.5 6l3 3 3-3" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/><path d="M1 10v1a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1v-1" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/></svg>Export SFDC-APAC</button>
+</div>
 
 <!-- Import CSV Modal -->
 <div id="imp-modal">
@@ -769,17 +791,88 @@ function exportCSV() {
   a.download=`FortiBOM_${p.cust.replace(/[^a-zA-Z0-9]/g,'_')}_${new Date().toISOString().slice(0,10)}.csv`;
   a.click(); toast('✓ CSV exported');
 }
-function copyTSV() {
-  const lines=['Product Group\tPart Number\tDescription\tQty\tType\tNotes'];
-  for (const entry of cart) {
-    lines.push(`${entry.label}\t\t\t\t\t`);
-    for (const r of rowsWithTerm(entry.rows)) {
-      if (r.section!==undefined) lines.push(`\t--- ${r.section} ---\t\t\t\t`);
-      else lines.push(`\t${r.sku||''}\t${r.desc||''}\t${r.qty??''}\t${r.kind||''}\t${r.note||''}`);
-    }
-    lines.push('');
+// ── COPY / EXPORT DROPDOWN ───────────────────────────────────────────────────
+function toggleCopyMenu(e) {
+  e.stopPropagation();
+  const menu = document.getElementById('copy-menu');
+  if (menu.classList.contains('on')) { menu.classList.remove('on'); return; }
+  const rect = e.currentTarget.getBoundingClientRect();
+  menu.style.top  = (rect.bottom + 4) + 'px';
+  menu.style.left = rect.left + 'px';
+  menu.classList.add('on');
+}
+function closeCopyMenu() { document.getElementById('copy-menu').classList.remove('on'); }
+document.addEventListener('click', function(e) {
+  const m = document.getElementById('copy-menu');
+  if (m && !m.contains(e.target) && e.target.id !== 'copy-export-btn') m.classList.remove('on');
+});
+
+function clipboardWrite(text, msg) {
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(text).then(() => toast(msg), () => clipboardFallback(text, msg));
+  } else {
+    clipboardFallback(text, msg);
   }
-  navigator.clipboard.writeText(lines.join('\n')).then(()=>toast('✓ Copied to clipboard'));
+}
+function clipboardFallback(text, msg) {
+  const ta = document.createElement('textarea');
+  ta.value = text;
+  ta.style.cssText = 'position:fixed;left:-9999px;top:-9999px;opacity:0;';
+  document.body.appendChild(ta);
+  ta.focus(); ta.select();
+  try { document.execCommand('copy'); toast(msg); }
+  catch(e) { toast('⚠ Copy failed — please copy manually'); }
+  document.body.removeChild(ta);
+}
+
+function bomDataRows() {
+  const out = [];
+  for (const entry of cart) {
+    if (entry._type === 'group') continue;
+    for (const r of rowsWithTerm(entry.rows)) {
+      if (r.section !== undefined) continue;
+      out.push(r);
+    }
+  }
+  return out;
+}
+
+function copyTSV() {
+  closeCopyMenu();
+  const lines = ['Part Number\tDescription\tQty\tNotes'];
+  for (const r of bomDataRows()) lines.push(`${r.sku||''}\t${r.desc||''}\t${r.qty??''}\t${r.note||''}`);
+  clipboardWrite(lines.join('\n'), '✓ TSV copied to clipboard');
+}
+function copyBOMCSV() {
+  closeCopyMenu();
+  const rows = [['Part Number','Description','Qty','Notes']];
+  for (const r of bomDataRows()) rows.push([r.sku||'', r.desc||'', r.qty??'', r.note||'']);
+  const csv = rows.map(r => r.map(c => `"${String(c).replace(/"/g,'""')}"`).join(',')).join('\r\n');
+  clipboardWrite(csv, '✓ CSV copied to clipboard');
+}
+function copyMD() {
+  closeCopyMenu();
+  const hdrs = ['Part Number','Description','Qty','Notes'];
+  const lines = ['| ' + hdrs.join(' | ') + ' |', '| ' + hdrs.map(() => '---').join(' | ') + ' |'];
+  for (const r of bomDataRows()) {
+    const cells = [r.sku||'', r.desc||'', String(r.qty??''), r.note||''];
+    lines.push('| ' + cells.map(c => c.replace(/\|/g,'\\|')).join(' | ') + ' |');
+  }
+  clipboardWrite(lines.join('\n'), '✓ Markdown copied to clipboard');
+}
+function exportSFDC(region) {
+  closeCopyMenu();
+  const rows = [['UID','Quantity','Disti Discount','Quote Line Item Notes']];
+  for (const r of bomDataRows()) {
+    if (!r.sku) continue;
+    rows.push([`${r.sku}-${region}`, r.qty??'', 28, r.note||'']);
+  }
+  const csv = rows.map(r => r.map(c => `"${String(c).replace(/"/g,'""')}"`).join(',')).join('\r\n');
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(new Blob([csv],{type:'text/csv;charset=utf-8;'}));
+  a.download = `SFDC_${region}_${new Date().toISOString().slice(0,10)}.csv`;
+  a.click();
+  toast(`✓ SFDC-${region} CSV exported`);
 }
 
 // ── IMPORT CSV ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Replaced the single "Copy TSV" button with a comprehensive dropdown menu that provides multiple copy and export options for BOM data in different formats.

## Key Changes
- **New dropdown menu UI**: Added styled dropdown menu (`#copy-menu`) with sections for clipboard operations and SFDC exports
- **Replaced button**: Changed "Copy TSV" button to "Copy / Export" with dropdown toggle functionality
- **Multiple copy formats**: 
  - Copy TSV (tab-separated values)
  - Copy CSV (comma-separated values with proper escaping)
  - Copy Markdown (formatted as markdown table)
- **SFDC regional exports**: Added three regional CSV export options (AMER, EMEA, APAC) with region-specific UID formatting
- **Improved clipboard handling**: Implemented `clipboardWrite()` and `clipboardFallback()` functions for better cross-browser compatibility
- **Refactored data extraction**: Created `bomDataRows()` helper function to centralize BOM data row filtering logic

## Implementation Details
- Dropdown menu uses `position:fixed` to escape overflow-y:auto parent containers
- Menu positioning calculated relative to button location with 4px offset
- Click-outside detection automatically closes the menu
- All copy operations show toast notifications with appropriate messages
- CSV exports properly escape quotes and use CRLF line endings
- SFDC exports include region suffix in UID and fixed 28% disti discount

https://claude.ai/code/session_01FdXxSEK5jwQuCXuKMph2zk