### PR TITLE
Increase Type column width in parts table

### DIFF
--- a/index.html
+++ b/index.html
@@ -617,7 +617,7 @@ function renderGroups() {
         </div>
         <div class="bt-wrap"><table class="bt"><thead><tr>
           <th style="width:200px;">Part Number</th><th>Description</th>
-          <th style="width:50px;text-align:center;">Qty</th><th style="width:80px;">Type</th><th>Notes</th>
+          <th style="width:50px;text-align:center;">Qty</th><th style="width:100px;">Type</th><th>Notes</th>
         </tr></thead><tbody>${rows}</tbody></table></div>`;
       addDragListeners(el);
       c.appendChild(el);


### PR DESCRIPTION
## Summary
Adjusted the width of the "Type" column in the parts table to improve readability and accommodate longer content.

## Changes
- Increased the `width` style property of the "Type" table header from `80px` to `100px`

## Details
This change provides additional horizontal space for the Type column in the bill of materials table, allowing for better display of type values without text wrapping or truncation.

https://claude.ai/code/session_01Afe7E975TxAjaDfAu74HPW