### PR TITLE
Fix mobile table layout in all product bomgen pages

### DIFF
--- a/products/custom-sku-bomgen.html
+++ b/products/custom-sku-bomgen.html
@@ -534,7 +534,7 @@ tbody tr:nth-child(even) td { background: var(--forti-table-stripe); }
       <button class="btn btn-secondary btn-sm" onclick="window.print()">Print</button>
     </div>
   </div>
-  <div class="card-body" style="padding:0;">
+  <div class="card-body" style="padding:0;overflow-x:auto;-webkit-overflow-scrolling:touch;">
     <table>
       <thead>
         <tr>

--- a/products/fortiadc-bomgen.html
+++ b/products/fortiadc-bomgen.html
@@ -79,7 +79,8 @@ tbody tr:nth-child(even) td{background:var(--forti-table-stripe)}
 .cb-label{flex:1}
 .cb-label strong{font-size:12px;color:var(--forti-text)}
 .cb-label .nc{display:block;margin-top:1px}
-.feat-table{width:100%;border-collapse:collapse;font-size:11px}
+#hw-spec-table{overflow-x:auto;-webkit-overflow-scrolling:touch;}
+.feat-table{width:100%;border-collapse:collapse;font-size:11px;min-width:400px;}
 .feat-table th{background:var(--forti-table-head);border:1px solid var(--forti-border);padding:5px 8px;text-align:center;font-size:10px;text-transform:uppercase;letter-spacing:.05em;color:var(--forti-text-secondary)}
 .feat-table th.left{text-align:left}
 .feat-table td{border:1px solid var(--forti-border);padding:4px 8px;text-align:center;vertical-align:middle}
@@ -117,7 +118,7 @@ tbody tr:nth-child(even) td{background:var(--forti-table-stripe)}
 <div class="card">
   <div class="card-header"><h2>Bundle Feature Comparison</h2></div>
   <div class="card-body">
-    <table class="feat-table" style="margin-bottom:10px">
+    <div style="overflow-x:auto;-webkit-overflow-scrolling:touch;"><table class="feat-table" style="margin-bottom:10px">
       <thead>
         <tr>
           <th class="left" style="width:42%">Feature</th>
@@ -138,7 +139,7 @@ tbody tr:nth-child(even) td{background:var(--forti-table-stripe)}
         <tr><td class="left">FortiGuard Advanced Bot Protection</td><td><span class="dash">—</span></td><td><span class="dash">—</span></td><td><span class="check">✔</span></td></tr>
         <tr><td class="left">FortiCare Premium Support</td><td><span class="check">✔</span></td><td><span class="check">✔</span></td><td><span class="check">✔</span></td></tr>
       </tbody>
-    </table>
+    </table></div>
     <div class="callout info">ℹ️ All bundles include FortiCare Premium Support. The AI Security bundle adds Threat Analytics, Advanced Bot Protection, and AI-Assist tokens on top of all Application Security features.</div>
   </div>
 </div>
@@ -273,7 +274,7 @@ tbody tr:nth-child(even) td{background:var(--forti-table-stripe)}
       <button class="btn btn-ghost" style="font-size:11px;padding:4px 10px" onclick="window.print()">Print</button>
     </div>
   </div>
-  <div class="card-body" style="padding:0">
+  <div class="card-body" style="padding:0;overflow-x:auto;-webkit-overflow-scrolling:touch;">
     <table id="bom-table">
       <thead>
         <tr>

--- a/products/fortiap-bomgen.html
+++ b/products/fortiap-bomgen.html
@@ -92,7 +92,8 @@
   .bom-meta{display:flex;gap:18px;flex-wrap:wrap;margin-bottom:14px;}
   .bom-meta-item .ml{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--textm);}
   .bom-meta-item .mv{font-size:13px;font-weight:500;color:var(--text);}
-  table.bt{width:100%;border-collapse:collapse;font-size:12px;}
+  .bt-wrap{overflow-x:auto;-webkit-overflow-scrolling:touch;}
+  table.bt{width:100%;border-collapse:collapse;font-size:12px;min-width:580px;}
   table.bt thead th{background:var(--th);border:1px solid var(--border);padding:7px 11px;text-align:left;font-weight:700;font-size:10px;text-transform:uppercase;letter-spacing:.05em;color:var(--text2);white-space:nowrap;}
   table.bt tbody td{border:1px solid var(--border);padding:7px 11px;vertical-align:top;}
   table.bt tbody tr:nth-child(even) td{background:var(--ts);}
@@ -257,7 +258,7 @@
   </div>
   <div class="cb">
     <div class="bom-meta" id="bom-meta"></div>
-    <table class="bt" id="bom-table">
+    <div class="bt-wrap"><table class="bt" id="bom-table">
       <thead><tr>
         <th style="width:230px;">Part Number</th>
         <th>Description</th>
@@ -266,7 +267,7 @@
         <th>Notes</th>
       </tr></thead>
       <tbody id="bom-tbody"></tbody>
-    </table>
+    </table></div>
     <div class="bom-totals" id="bom-totals"></div>
   </div>
 </div>

--- a/products/fortiflex-bomgen.html
+++ b/products/fortiflex-bomgen.html
@@ -285,7 +285,7 @@ tbody tr:nth-child(even) td { background: var(--forti-table-stripe); }
 ══════════════════════════════════════ -->
 <div class="card">
   <div class="card-head">Program Overview</div>
-  <div class="card-body">
+  <div class="card-body" style="overflow-x:auto;-webkit-overflow-scrolling:touch;">
     <table>
       <thead>
         <tr>
@@ -317,7 +317,7 @@ tbody tr:nth-child(even) td { background: var(--forti-table-stripe); }
       </tbody>
     </table>
 
-    <div style="margin-top:14px;">
+    <div style="margin-top:14px;overflow-x:auto;-webkit-overflow-scrolling:touch;">
       <table>
         <thead>
           <tr>
@@ -472,7 +472,7 @@ tbody tr:nth-child(even) td { background: var(--forti-table-stripe); }
       <button class="btn-neutral btn-sm" onclick="copyTSV()">⎘ Copy TSV</button>
       <button class="btn-neutral btn-sm" onclick="window.print()">⎙ Print</button>
     </div>
-    <table id="bom-table">
+    <div style="overflow-x:auto;-webkit-overflow-scrolling:touch;"><table id="bom-table">
       <thead>
         <tr>
           <th style="width:200px;">Part Number</th>
@@ -483,7 +483,7 @@ tbody tr:nth-child(even) td { background: var(--forti-table-stripe); }
         </tr>
       </thead>
       <tbody id="bom-tbody"></tbody>
-    </table>
+    </table></div>
   </div>
 </div>
 

--- a/products/fortigate-bomgen.html
+++ b/products/fortigate-bomgen.html
@@ -108,7 +108,8 @@
   .bom-meta{display:flex;gap:18px;flex-wrap:wrap;margin-bottom:14px;}
   .bom-meta-item .ml{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--textm);}
   .bom-meta-item .mv{font-size:13px;font-weight:500;color:var(--text);}
-  table.bt{width:100%;border-collapse:collapse;font-size:12px;}
+  .bt-wrap{overflow-x:auto;-webkit-overflow-scrolling:touch;}
+  table.bt{width:100%;border-collapse:collapse;font-size:12px;min-width:580px;}
   table.bt thead th{background:var(--th);border:1px solid var(--border);padding:7px 11px;text-align:left;font-weight:700;font-size:10px;text-transform:uppercase;letter-spacing:.05em;color:var(--text2);white-space:nowrap;}
   table.bt tbody td{border:1px solid var(--border);padding:7px 11px;vertical-align:top;}
   table.bt tbody tr:nth-child(even) td{background:var(--ts);}
@@ -444,7 +445,7 @@
   </div>
   <div class="cb">
     <div class="bom-meta" id="bom-meta"></div>
-    <table class="bt" id="bom-table">
+    <div class="bt-wrap"><table class="bt" id="bom-table">
       <thead><tr>
         <th style="width:230px;">Part Number</th>
         <th>Description</th>
@@ -453,7 +454,7 @@
         <th>Notes</th>
       </tr></thead>
       <tbody id="bom-tbody"></tbody>
-    </table>
+    </table></div>
     <div class="bom-totals" id="bom-totals"></div>
   </div>
 </div>

--- a/products/fortimanager-bomgen.html
+++ b/products/fortimanager-bomgen.html
@@ -120,7 +120,8 @@
   .bom-meta{display:flex;gap:18px;flex-wrap:wrap;margin-bottom:14px;}
   .bom-meta-item .ml{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--textm);}
   .bom-meta-item .mv{font-size:13px;font-weight:500;color:var(--text);}
-  table.bt{width:100%;border-collapse:collapse;font-size:12px;}
+  .bt-wrap{overflow-x:auto;-webkit-overflow-scrolling:touch;}
+  table.bt{width:100%;border-collapse:collapse;font-size:12px;min-width:580px;}
   table.bt thead th{background:var(--th);border:1px solid var(--border);padding:7px 11px;text-align:left;font-weight:700;font-size:10px;text-transform:uppercase;letter-spacing:.05em;color:var(--text2);white-space:nowrap;}
   table.bt tbody td{border:1px solid var(--border);padding:7px 11px;vertical-align:top;}
   table.bt tbody tr:nth-child(even) td{background:var(--ts);}
@@ -490,7 +491,7 @@
   </div>
   <div class="cb">
     <div class="bom-meta" id="bom-meta"></div>
-    <table class="bt" id="bom-table">
+    <div class="bt-wrap"><table class="bt" id="bom-table">
       <thead><tr>
         <th style="width:230px;">Part Number</th>
         <th>Description</th>
@@ -499,7 +500,7 @@
         <th>Notes</th>
       </tr></thead>
       <tbody id="bom-tbody"></tbody>
-    </table>
+    </table></div>
     <div class="bom-totals" id="bom-totals"></div>
   </div>
 </div>

--- a/products/fortinac-bomgen.html
+++ b/products/fortinac-bomgen.html
@@ -153,7 +153,8 @@
   .bom-meta-item .meta-label { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.07em; color: var(--forti-text-muted); }
   .bom-meta-item .meta-value { font-size: 13px; font-weight: 500; color: var(--forti-text); }
 
-  table.bom-table { width: 100%; border-collapse: collapse; font-size: 12px; }
+  .bt-wrap{overflow-x:auto;-webkit-overflow-scrolling:touch;}
+  table.bom-table { width: 100%; border-collapse: collapse; font-size: 12px; min-width: 580px; }
   table.bom-table thead th {
     background: var(--forti-table-head); border: 1px solid var(--forti-border);
     padding: 7px 11px; text-align: left; font-weight: 700;
@@ -453,7 +454,7 @@
   </div>
   <div class="card-body">
     <div class="bom-meta" id="bom-meta"></div>
-    <table class="bom-table" id="bom-table">
+    <div class="bt-wrap"><table class="bom-table" id="bom-table">
       <thead>
         <tr>
           <th style="width:195px;">Part Number</th>
@@ -464,7 +465,7 @@
         </tr>
       </thead>
       <tbody id="bom-tbody"></tbody>
-    </table>
+    </table></div>
     <div class="bom-totals" id="bom-totals"></div>
   </div>
 </div>

--- a/products/fortisase-bomgen.html
+++ b/products/fortisase-bomgen.html
@@ -102,7 +102,8 @@
   .bom-meta{display:flex;gap:18px;flex-wrap:wrap;margin-bottom:14px;}
   .bom-meta-item .ml{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--textm);}
   .bom-meta-item .mv{font-size:13px;font-weight:500;color:var(--text);}
-  table.bt{width:100%;border-collapse:collapse;font-size:12px;}
+  .bt-wrap{overflow-x:auto;-webkit-overflow-scrolling:touch;}
+  table.bt{width:100%;border-collapse:collapse;font-size:12px;min-width:580px;}
   table.bt thead th{background:var(--th);border:1px solid var(--border);padding:7px 11px;text-align:left;font-weight:700;font-size:10px;text-transform:uppercase;letter-spacing:.05em;color:var(--text2);white-space:nowrap;}
   table.bt tbody td{border:1px solid var(--border);padding:7px 11px;vertical-align:top;}
   table.bt tbody tr:nth-child(even) td{background:var(--ts);}
@@ -478,7 +479,7 @@
   </div>
   <div class="cb">
     <div class="bom-meta" id="bom-meta"></div>
-    <table class="bt" id="bom-table">
+    <div class="bt-wrap"><table class="bt" id="bom-table">
       <thead><tr>
         <th style="width:215px;">Part Number</th>
         <th>Description</th>
@@ -487,7 +488,7 @@
         <th>Notes</th>
       </tr></thead>
       <tbody id="bom-tbody"></tbody>
-    </table>
+    </table></div>
     <div class="bom-totals" id="bom-totals"></div>
   </div>
 </div>

--- a/products/fortisiem-bomgen.html
+++ b/products/fortisiem-bomgen.html
@@ -116,7 +116,7 @@ tbody tr:nth-child(even) td{background:var(--forti-table-stripe)}
       <span>ℹ</span>
       <span>FortiSIEM licensing models are <strong>mutually exclusive</strong> — they cannot be combined. Select the appropriate model tab below.</span>
     </div>
-    <table class="ov-table">
+    <div style="overflow-x:auto;-webkit-overflow-scrolling:touch;"><table class="ov-table">
       <thead>
         <tr>
           <th class="left" style="text-align:left">Feature</th>
@@ -137,7 +137,7 @@ tbody tr:nth-child(even) td{background:var(--forti-table-stripe)}
         <tr><td class="left">EPS</td><td>10/device</td><td>10/device</td><td>Unlimited</td><td>Per FCU</td><td>Unlimited</td></tr>
         <tr><td class="left">Min. Order</td><td>50 devices</td><td>50 devices</td><td>40 GB/day</td><td>10 FCU + 500GB</td><td>MSSP Agmt</td></tr>
       </tbody>
-    </table>
+    </table></div>
   </div>
 </div>
 
@@ -474,7 +474,7 @@ tbody tr:nth-child(even) td{background:var(--forti-table-stripe)}
         <button class="btn-default" style="padding:4px 10px;font-size:11px" onclick="window.print()">Print</button>
       </div>
     </div>
-    <div class="card-body" style="padding:0">
+    <div class="card-body" style="padding:0;overflow-x:auto;-webkit-overflow-scrolling:touch;">
       <table>
         <thead><tr><th style="width:200px">Part Number</th><th>Description</th><th style="width:50px;text-align:center">Qty</th><th style="width:80px;text-align:center">Type</th><th style="width:160px">Notes</th></tr></thead>
         <tbody id="bom-tbody"></tbody>

--- a/products/fortiswitch-bomgen.html
+++ b/products/fortiswitch-bomgen.html
@@ -97,7 +97,8 @@
   .bom-meta{display:flex;gap:18px;flex-wrap:wrap;margin-bottom:14px;}
   .bom-meta-item .ml{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--textm);}
   .bom-meta-item .mv{font-size:13px;font-weight:500;color:var(--text);}
-  table.bt{width:100%;border-collapse:collapse;font-size:12px;}
+  .bt-wrap{overflow-x:auto;-webkit-overflow-scrolling:touch;}
+  table.bt{width:100%;border-collapse:collapse;font-size:12px;min-width:580px;}
   table.bt thead th{background:var(--th);border:1px solid var(--border);padding:7px 11px;text-align:left;font-weight:700;font-size:10px;text-transform:uppercase;letter-spacing:.05em;color:var(--text2);white-space:nowrap;}
   table.bt tbody td{border:1px solid var(--border);padding:7px 11px;vertical-align:top;}
   table.bt tbody tr:nth-child(even) td{background:var(--ts);}
@@ -255,7 +256,7 @@
   </div>
   <div class="cb">
     <div class="bom-meta" id="bom-meta"></div>
-    <table class="bt" id="bom-table">
+    <div class="bt-wrap"><table class="bt" id="bom-table">
       <thead><tr>
         <th style="width:215px;">Part Number</th>
         <th>Description</th>
@@ -264,7 +265,7 @@
         <th>Notes</th>
       </tr></thead>
       <tbody id="bom-tbody"></tbody>
-    </table>
+    </table></div>
     <div class="bom-totals" id="bom-totals"></div>
   </div>
 </div>

--- a/products/placeholder-bomgen.html
+++ b/products/placeholder-bomgen.html
@@ -294,10 +294,12 @@
     color: var(--forti-text);
   }
 
+  .bt-wrap{overflow-x:auto;-webkit-overflow-scrolling:touch;}
   table.bom-table {
     width: 100%;
     border-collapse: collapse;
     font-size: 12.5px;
+    min-width: 580px;
   }
 
   table.bom-table thead th {
@@ -567,7 +569,7 @@
     <div class="bom-meta" id="bom-meta"></div>
 
     <!-- BOM table -->
-    <table class="bom-table" id="bom-table">
+    <div class="bt-wrap"><table class="bom-table" id="bom-table">
       <thead>
         <tr>
           <th style="width:200px;">Part Number / SKU</th>
@@ -579,7 +581,7 @@
       </thead>
       <tbody id="bom-tbody">
       </tbody>
-    </table>
+    </table></div>
 
     <!-- Totals -->
     <div class="bom-totals" id="bom-totals"></div>


### PR DESCRIPTION
Apply the same horizontal-scroll fix from index.html to all product pages. Tables now render at a minimum readable width (580px for BOM tables) inside overflow-x:auto wrappers so mobile users can swipe left/right instead of seeing squished/overlapping columns.

Files updated:
- fortigate, fortiap, fortisase, fortiswitch, fortimanager: .bt-wrap CSS class + min-width on table.bt + HTML wrapper
- fortinac, placeholder: same pattern for table.bom-table
- fortiadc: overflow-x on BOM card-body, feat-table wrapper, CSS for dynamically-generated #hw-spec-table
- fortiflex: overflow-x on BOM table wrapper + two overview tables
- fortisiem: overflow-x on BOM table + ov-table wrapper

Already-fixed files untouched: fortianalyzer, fortiauthenticator, fortisandbox, fortiaiops, fortideceptor, fortimonitor, fortiweb, forticlient

https://claude.ai/code/session_017crqTex8mgmScq6bBXEb19