### PR TITLE
Rename FortiBOM to FabricBOM in breadcrumb navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -286,7 +286,7 @@
 
   <div id="content">
     <div id="ch">
-      <span class="bci">FortiBOM</span>
+      <span class="bci">FabricBOM</span>
       <span class="bcs">›</span>
       <span class="bci cur" id="bc">Select a product</span>
     </div>


### PR DESCRIPTION
## Summary
Updated the breadcrumb navigation label from "FortiBOM" to "FabricBOM" to reflect the correct product name.

## Changes
- Changed the breadcrumb label text from "FortiBOM" to "FabricBOM" in the navigation header

## Details
This is a simple text update to the breadcrumb navigation component that displays the product name to users. The change affects the visual branding/labeling shown in the page header navigation.

https://claude.ai/code/session_01HRo6FzGCkMHze4ZtQGMdUL