### PR TITLE
Fix FS-148F missing FPoE SKU and care SKU (Issue #16)

### DIFF
--- a/products/fortiswitch-bomgen.html
+++ b/products/fortiswitch-bomgen.html
@@ -333,7 +333,7 @@ const MODELS = [
     features:['FortiLink','Access Security','Netflow','Multitier'],
     hwSku:'FS-148F', careSku:'FC-10-148FN-247-02-DD',
     poeSku:'FS-148F-POE', carePoe:'FC-10-148FP-247-02-DD',
-    fpoeSku:null, careFpoe:null,
+    fpoeSku:'FS-148F-FPOE', careFpoe:'FC-10-148FF-247-02-DD',
     advLicSku:null, cloudTier:'00',
     psu:null, tranProfile:'10g',
   },


### PR DESCRIPTION
Add fpoeSku:'FS-148F-FPOE' and careFpoe:'FC-10-148FF-247-02-DD' to the
FS-148F model definition, enabling the Full PoE dropdown option.

https://claude.ai/code/session_0177pnDuWRPmrDhDNkF7HYTr