### PR TITLE
Add text color styling to pricing table headers

### DIFF
--- a/index.html
+++ b/index.html
@@ -746,7 +746,7 @@ async function renderGroups() {
         </div>
         <div class="bt-wrap"><table class="bt"><thead><tr>
           <th style="width:200px;">Part Number</th><th>Description</th>
-          <th style="width:50px;text-align:center;">Qty</th><th style="width:100px;">Type</th><th>Notes</th>${hasPricing ? '<th style="width:110px;text-align:right;">List Price</th><th style="width:120px;text-align:right;">Total Price</th>' : ''}
+          <th style="width:50px;text-align:center;">Qty</th><th style="width:100px;">Type</th><th>Notes</th>${hasPricing ? '<th style="width:110px;text-align:right;color:var(--c-text);">List Price</th><th style="width:120px;text-align:right;color:var(--c-text);">Total Price</th>' : ''}
         </tr></thead><tbody>${rows}</tbody></table></div>`;
       addDragListeners(el);
       c.appendChild(el);


### PR DESCRIPTION
## Summary
Applied explicit text color styling to the pricing column headers in the parts table to ensure consistent color appearance across different themes or display contexts.

## Changes
- Added `color:var(--c-text);` CSS property to both "List Price" and "Total Price" table headers
- This ensures the pricing headers respect the theme's text color variable instead of inheriting potentially inconsistent colors

## Implementation Details
The change targets the conditional pricing columns that are only rendered when `hasPricing` is true. By using the CSS custom property `--c-text`, the styling remains consistent with the application's theming system and adapts automatically to light/dark mode or other theme variations.

https://claude.ai/code/session_01AJUCdGNM91ibdGi6nCB55n