### PR TITLE
Add autocomplete dropdown for SKU and description fields

### DIFF
--- a/products/custom-sku-bomgen.html
+++ b/products/custom-sku-bomgen.html
@@ -418,6 +418,42 @@ tbody tr:nth-child(even) td { background: var(--forti-table-stripe); }
   padding: 1px 6px;
   margin-left: 6px;
 }
+
+/* ── Autocomplete Dropdown ── */
+.ac-dropdown {
+  position: fixed;
+  z-index: 9999;
+  background: white;
+  border: 1px solid var(--forti-input-border);
+  border-radius: 3px;
+  box-shadow: 0 4px 12px rgba(0,0,0,.15);
+  max-height: 260px;
+  overflow-y: auto;
+  display: none;
+  min-width: 300px;
+}
+.ac-item {
+  padding: 7px 10px;
+  cursor: pointer;
+  border-bottom: 1px solid var(--forti-border);
+}
+.ac-item:last-child { border-bottom: none; }
+.ac-item:hover, .ac-item.ac-item-active { background: var(--forti-info-bg); }
+.ac-item-sku {
+  font-family: 'Courier New', monospace;
+  font-size: 11px;
+  font-weight: 700;
+  color: #1A4E82;
+  letter-spacing: .03em;
+  text-transform: uppercase;
+}
+.ac-item-desc {
+  font-size: 11px;
+  color: var(--forti-text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 </style>
 </head>
 <body>
@@ -631,6 +667,8 @@ function addSkuRow(data) {
   tbody.appendChild(tr);
   updateRowNumbers();
   updateRowCountBadge();
+  attachSkuAutocomplete(id);
+  attachDescAutocomplete(id);
 }
 
 function addSectionRow(data) {
@@ -950,6 +988,260 @@ function escHtml(s) {
   return String(s)
     .replace(/&/g,'&amp;').replace(/</g,'&lt;')
     .replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+}
+
+// ─────────────────────────────────────────────
+//  Pricing IndexDB (same DB as index.html)
+// ─────────────────────────────────────────────
+let _pricingDb = null;
+let _pricingCache = null;
+let _pricingLoaded = false;
+
+function openPricingDB() {
+  if (_pricingDb) return Promise.resolve(_pricingDb);
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open('fabricbom_pricing', 1);
+    req.onupgradeneeded = e => e.target.result.createObjectStore('pricing');
+    req.onsuccess = e => { _pricingDb = e.target.result; resolve(_pricingDb); };
+    req.onerror = e => reject(e.target.error);
+  });
+}
+
+async function getPricingData() {
+  if (_pricingLoaded) return _pricingCache;
+  try {
+    const db = await openPricingDB();
+    const data = await new Promise((resolve, reject) => {
+      const tx = db.transaction('pricing', 'readonly');
+      const req = tx.objectStore('pricing').get('current');
+      req.onsuccess = e => resolve(e.target.result || null);
+      req.onerror = e => reject(e.target.error);
+    });
+    _pricingCache = data;
+    _pricingLoaded = true;
+    return data;
+  } catch(e) {
+    _pricingLoaded = true;
+    _pricingCache = null;
+    return null;
+  }
+}
+
+// ─────────────────────────────────────────────
+//  Autocomplete — singleton dropdown
+// ─────────────────────────────────────────────
+let _acDropdown = null;
+let _acOnSelect = null;
+let _acItems = [];
+let _acIndex = -1;
+
+function getAcDropdown() {
+  if (!_acDropdown) {
+    _acDropdown = document.createElement('div');
+    _acDropdown.className = 'ac-dropdown';
+    _acDropdown.addEventListener('mousedown', e => e.preventDefault());
+    document.body.appendChild(_acDropdown);
+  }
+  return _acDropdown;
+}
+
+function showAcDropdown(inputEl, items, onSelect) {
+  const dd = getAcDropdown();
+  _acOnSelect = onSelect;
+  _acItems = items;
+  _acIndex = -1;
+
+  dd.innerHTML = '';
+  if (!items.length) { hideAcDropdown(); return; }
+
+  items.forEach((item, i) => {
+    const div = document.createElement('div');
+    div.className = 'ac-item';
+    const skuDiv = document.createElement('div');
+    skuDiv.className = 'ac-item-sku';
+    skuDiv.textContent = item.sku;
+    const descDiv = document.createElement('div');
+    descDiv.className = 'ac-item-desc';
+    descDiv.textContent = item.desc1;
+    div.appendChild(skuDiv);
+    div.appendChild(descDiv);
+    div.addEventListener('mouseenter', () => setAcActiveIndex(i));
+    div.addEventListener('mousedown', () => {
+      _acOnSelect && _acOnSelect(_acItems[i]);
+      hideAcDropdown();
+    });
+    dd.appendChild(div);
+  });
+
+  const rect = inputEl.getBoundingClientRect();
+  dd.style.display = 'block';
+  dd.style.top  = (rect.bottom + 2) + 'px';
+  dd.style.left = rect.left + 'px';
+  dd.style.width = Math.max(rect.width, 320) + 'px';
+}
+
+function hideAcDropdown() {
+  if (_acDropdown) _acDropdown.style.display = 'none';
+  _acItems = [];
+  _acIndex = -1;
+  _acOnSelect = null;
+}
+
+function setAcActiveIndex(i) {
+  _acIndex = i;
+  if (!_acDropdown) return;
+  _acDropdown.querySelectorAll('.ac-item').forEach((el, idx) => {
+    el.classList.toggle('ac-item-active', idx === i);
+    if (idx === i) el.scrollIntoView({ block: 'nearest' });
+  });
+}
+
+function acKeydown(e) {
+  if (!_acDropdown || _acDropdown.style.display === 'none') return;
+  if (e.key === 'ArrowDown') {
+    e.preventDefault();
+    setAcActiveIndex(Math.min(_acIndex + 1, _acItems.length - 1));
+  } else if (e.key === 'ArrowUp') {
+    e.preventDefault();
+    setAcActiveIndex(Math.max(_acIndex - 1, 0));
+  } else if (e.key === 'Enter') {
+    if (_acIndex >= 0) {
+      e.preventDefault();
+      _acOnSelect && _acOnSelect(_acItems[_acIndex]);
+    }
+    hideAcDropdown();
+  } else if (e.key === 'Escape') {
+    e.preventDefault();
+    hideAcDropdown();
+  }
+}
+
+document.addEventListener('click', e => {
+  if (_acDropdown && !_acDropdown.contains(e.target)) hideAcDropdown();
+});
+
+// ─────────────────────────────────────────────
+//  Pricing search helpers
+// ─────────────────────────────────────────────
+function rowToAcItem(row) {
+  return {
+    sku:     row.SKU || '',
+    desc1:   row['Description #1'] || '',
+    desc2:   row['Description #2'] || '',
+    product: row.Product || '',
+    item:    row.Item || '',
+  };
+}
+
+async function searchBySku(query) {
+  const data = await getPricingData();
+  if (!data || !data.rows) return [];
+  const q = query.trim().toUpperCase();
+  if (q.length < 2) return [];
+  return data.rows
+    .filter(row => (row.SKU || '').toUpperCase().includes(q))
+    .slice(0, 15)
+    .map(rowToAcItem);
+}
+
+async function searchByDesc(query) {
+  const data = await getPricingData();
+  if (!data || !data.rows) return [];
+  const q = query.trim().toLowerCase();
+  if (q.length < 3) return [];
+  return data.rows
+    .filter(row => (row['Description #1'] || '').toLowerCase().includes(q))
+    .slice(0, 15)
+    .map(rowToAcItem);
+}
+
+async function findExactSku(sku) {
+  const data = await getPricingData();
+  if (!data || !data.rows) return null;
+  const q = sku.trim().toUpperCase();
+  const row = data.rows.find(r => (r.SKU || '').toUpperCase() === q);
+  return row ? rowToAcItem(row) : null;
+}
+
+async function findExactDesc(desc) {
+  const data = await getPricingData();
+  if (!data || !data.rows) return null;
+  const q = desc.trim().toLowerCase();
+  const row = data.rows.find(r => (r['Description #1'] || '').toLowerCase() === q);
+  return row ? rowToAcItem(row) : null;
+}
+
+// ─────────────────────────────────────────────
+//  Fill row fields from a pricing match
+// ─────────────────────────────────────────────
+function fillRowFromPricing(id, item) {
+  const skuEl = document.getElementById(`sku-${id}`);
+  if (skuEl) skuEl.value = item.sku.toUpperCase();
+
+  const descEl = document.getElementById(`desc-${id}`);
+  if (descEl) descEl.value = item.desc1;
+
+  const notesEl = document.getElementById(`notes-${id}`);
+  if (notesEl) notesEl.value = item.desc2;
+
+  const groupEl = document.getElementById('f-group-name');
+  if (groupEl && !groupEl.value.trim() && item.product)
+    groupEl.value = item.product;
+
+  const sectionEl = document.getElementById('f-section-label');
+  if (sectionEl && !sectionEl.value.trim() && item.item)
+    sectionEl.value = item.item;
+
+  clearRowErr(id);
+}
+
+// ─────────────────────────────────────────────
+//  Attach autocomplete to a row's inputs
+// ─────────────────────────────────────────────
+function attachSkuAutocomplete(id) {
+  const inputEl = document.getElementById(`sku-${id}`);
+  if (!inputEl) return;
+
+  inputEl.addEventListener('input', async () => {
+    const q = inputEl.value;
+    if (q.trim().length < 2) { hideAcDropdown(); return; }
+    const matches = await searchBySku(q);
+    showAcDropdown(inputEl, matches, item => fillRowFromPricing(id, item));
+  });
+
+  inputEl.addEventListener('keydown', acKeydown);
+
+  inputEl.addEventListener('blur', async () => {
+    const q = inputEl.value.trim();
+    if (q) {
+      const match = await findExactSku(q);
+      if (match) fillRowFromPricing(id, match);
+    }
+    setTimeout(hideAcDropdown, 150);
+  });
+}
+
+function attachDescAutocomplete(id) {
+  const inputEl = document.getElementById(`desc-${id}`);
+  if (!inputEl) return;
+
+  inputEl.addEventListener('input', async () => {
+    const q = inputEl.value;
+    if (q.trim().length < 3) { hideAcDropdown(); return; }
+    const matches = await searchByDesc(q);
+    showAcDropdown(inputEl, matches, item => fillRowFromPricing(id, item));
+  });
+
+  inputEl.addEventListener('keydown', acKeydown);
+
+  inputEl.addEventListener('blur', async () => {
+    const q = inputEl.value.trim();
+    if (q) {
+      const match = await findExactDesc(q);
+      if (match) fillRowFromPricing(id, match);
+    }
+    setTimeout(hideAcDropdown, 150);
+  });
 }
 
 // ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
This PR adds an autocomplete dropdown feature to the SKU and description input fields in the BOM generator. Users can now search for products by SKU or description, with results populated from the pricing database stored in IndexedDB.

## Key Changes
- **Autocomplete UI**: Added styled dropdown component (`.ac-dropdown`, `.ac-item`, `.ac-item-sku`, `.ac-item-desc`) with fixed positioning, keyboard navigation support, and hover effects
- **Pricing Database Integration**: Implemented IndexedDB access to retrieve pricing data (same database as index.html) with caching to avoid repeated queries
- **Search Functions**: Added `searchBySku()` and `searchByDesc()` for filtering products with minimum query lengths (2 chars for SKU, 3 for description), returning up to 15 results
- **Exact Match Lookup**: Implemented `findExactSku()` and `findExactDesc()` to auto-fill row data when user leaves a field with an exact match
- **Keyboard Navigation**: Full keyboard support including arrow keys (up/down), Enter to select, and Escape to close
- **Row Auto-Population**: When a product is selected, the function `fillRowFromPricing()` populates SKU, description, notes, and optionally group/section fields
- **Event Attachment**: Modified `addRow()` to call `attachSkuAutocomplete()` and `attachDescAutocomplete()` for new rows, enabling autocomplete on dynamically created inputs

## Implementation Details
- Singleton dropdown pattern prevents multiple dropdown instances
- Dropdown positioning calculated relative to input field's bounding rectangle
- Mouse event handling includes `preventDefault()` to avoid input blur conflicts
- Global click listener closes dropdown when clicking outside
- Autocomplete items display both SKU (monospace, uppercase) and description with text truncation
- Active item auto-scrolls into view during keyboard navigation

https://claude.ai/code/session_0132qbqMYuaaM8evGy87PJjG