### PR TITLE
Add pricing DB autocomplete to Custom SKU part number and description fields

### DIFF
--- a/products/custom-sku-bomgen.html
+++ b/products/custom-sku-bomgen.html
@@ -1147,10 +1147,13 @@ async function searchBySku(query) {
 async function searchByDesc(query) {
   const data = await getPricingData();
   if (!data || !data.rows) return [];
-  const q = query.trim().toLowerCase();
-  if (q.length < 3) return [];
+  const terms = query.trim().toLowerCase().split(/\s+/).filter(t => t.length > 0);
+  if (!terms.length || terms[0].length < 3) return [];
   return data.rows
-    .filter(row => (row['Description #1'] || '').toLowerCase().includes(q))
+    .filter(row => {
+      const d = (row['Description #1'] || '').toLowerCase();
+      return terms.every(t => d.includes(t));
+    })
     .slice(0, 15)
     .map(rowToAcItem);
 }
@@ -1183,14 +1186,6 @@ function fillRowFromPricing(id, item) {
 
   const notesEl = document.getElementById(`notes-${id}`);
   if (notesEl) notesEl.value = item.desc2;
-
-  const groupEl = document.getElementById('f-group-name');
-  if (groupEl && !groupEl.value.trim() && item.product)
-    groupEl.value = item.product;
-
-  const sectionEl = document.getElementById('f-section-label');
-  if (sectionEl && !sectionEl.value.trim() && item.item)
-    sectionEl.value = item.item;
 
   clearRowErr(id);
 }


### PR DESCRIPTION
## Summary

- **Part Number field**: Autocomplete triggers after 2+ characters, searching the `SKU` column in `fabricbom_pricing` IndexedDB. Dropdown shows up to 15 matches with the SKU and Description #1 as a subtitle.
- **Description field**: Same behavior, searching `Description #1` after 3+ characters. Uses AND logic for multi-word queries (e.g. "901 Enterprise" matches "FortiGate-901G Hardware plus 1 Year ... Enterprise Protection").
- **On selection** (click, Enter key, or exact-match on tab/blur): auto-populates Part Number, Description, and Notes fields for that row.
- **No pricing data**: fields behave normally with no autocomplete shown.
- Group Name and Section Header Label are intentionally left as manual-entry only.

## Test plan

- [ ] Upload a Fortinet pricing CSV in the main index.html settings
- [ ] Open Custom SKU Entry, type "FG-" in Part Number — confirm dropdown appears with matching SKUs
- [ ] Select an entry — confirm Description and Notes fields populate
- [ ] Tab away from a fully-typed exact SKU — confirm fields auto-fill
- [ ] Type a two-word phrase in Description (e.g. "901 Enterprise") — confirm AND filtering works
- [ ] Type a value that doesn't exist in the DB — confirm no auto-fill occurs
- [ ] Confirm Group Name and Section Header Label are never auto-populated

https://claude.ai/code/session_0132qbqMYuaaM8evGy87PJjG