### PR TITLE
Normalize SKU term suffix and strip year from description on autocomplete fill

### DIFF
--- a/products/custom-sku-bomgen.html
+++ b/products/custom-sku-bomgen.html
@@ -1175,14 +1175,29 @@ async function findExactDesc(desc) {
 }
 
 // ─────────────────────────────────────────────
+//  Normalization helpers
+// ─────────────────────────────────────────────
+function normalizeSkuTerm(sku) {
+  // Replace Fortinet contract-term suffixes with -DD so the Project BOM
+  // term selector can substitute the correct value at export time.
+  return sku.replace(/-(?:12|24|36|48|60)$/i, '-DD');
+}
+
+function normalizeDesc(desc) {
+  // Strip leading year strings (e.g. "3 Year ", "1 Year ") so the
+  // description stays accurate when the term is changed in the Project BOM.
+  return desc.replace(/\b\d+\s+[Yy]ears?\s+/g, '');
+}
+
+// ─────────────────────────────────────────────
 //  Fill row fields from a pricing match
 // ─────────────────────────────────────────────
 function fillRowFromPricing(id, item) {
   const skuEl = document.getElementById(`sku-${id}`);
-  if (skuEl) skuEl.value = item.sku.toUpperCase();
+  if (skuEl) skuEl.value = normalizeSkuTerm(item.sku).toUpperCase();
 
   const descEl = document.getElementById(`desc-${id}`);
-  if (descEl) descEl.value = item.desc1;
+  if (descEl) descEl.value = normalizeDesc(item.desc1);
 
   const notesEl = document.getElementById(`notes-${id}`);
   if (notesEl) notesEl.value = item.desc2;


### PR DESCRIPTION
## Summary

- **SKU term normalization**: When a selected SKU ends in a Fortinet contract-term suffix (`-12`, `-24`, `-36`, `-48`, `-60`), it is replaced with `-DD` before populating the Part Number field so the Project BOM term selector works correctly at export time.
- **Description year stripping**: Removes year prefixes (e.g. `"3 Year "`, `"1 Year "`) from the description so it stays accurate when the term is changed in the Project BOM. For example: `"FortiADC-420F Hardware plus 3 Year FortiCare Premium and FortiADC Application Security Bundle"` becomes `"FortiADC-420F Hardware plus FortiCare Premium and FortiADC Application Security Bundle"`.

The autocomplete dropdown still shows the original DB values so the user can identify what they're selecting — normalization only fires when the fields are populated.

## Test plan

- [ ] Select a SKU ending in a term code (e.g. `-36`) — confirm Part Number field shows `-DD` instead
- [ ] Confirm the Project BOM term selector correctly substitutes the term on export
- [ ] Select a SKU whose Description #1 contains a year prefix — confirm it is stripped in the Description field
- [ ] Confirm Notes field is unaffected by year stripping

https://claude.ai/code/session_0132qbqMYuaaM8evGy87PJjG