### PR TITLE
Strip year prefix from Notes field on autocomplete fill

### DIFF
--- a/products/custom-sku-bomgen.html
+++ b/products/custom-sku-bomgen.html
@@ -1200,7 +1200,7 @@ function fillRowFromPricing(id, item) {
   if (descEl) descEl.value = normalizeDesc(item.desc1);
 
   const notesEl = document.getElementById(`notes-${id}`);
-  if (notesEl) notesEl.value = item.desc2;
+  if (notesEl) notesEl.value = normalizeDesc(item.desc2);
 
   clearRowErr(id);
 }


### PR DESCRIPTION
## Summary

Applies the same year-stripping normalization to the Notes field (Description #2) that was already applied to the Description field.

`"1 Year HW, FC Premium & ENT BDL SVC 7.4"` → `"HW, FC Premium & ENT BDL SVC 7.4"`

## Test plan

- [ ] Select a SKU from autocomplete whose Description #2 starts with a year prefix — confirm Notes field has it stripped
- [ ] Confirm Description field year stripping still works as before

https://claude.ai/code/session_0132qbqMYuaaM8evGy87PJjG