### PR TITLE
Add new Forti products to service worker cache

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'fabricbom-v1';
+const CACHE = 'fabricbom-v2';
 
 const SHELL = [
   './',
@@ -28,6 +28,14 @@ const SHELL = [
   './products/fortisiem-bomgen.html',
   './products/fortiflex-bomgen.html',
   './products/fortiedr-bomgen.html',
+  './products/fortiappsec-bomgen.html',
+  './products/forticnapp-bomgen.html',
+  './products/fortidlp-bomgen.html',
+  './products/fortiextender-bomgen.html',
+  './products/fortimail-bomgen.html',
+  './products/fortimail-workspace-bomgen.html',
+  './products/fortipresence-bomgen.html',
+  './products/fortirecon-bomgen.html',
   './products/custom-sku-bomgen.html',
 ];
 


### PR DESCRIPTION
## Summary
Updated the service worker cache configuration to include 8 new Forti product BOM generator pages and bumped the cache version to ensure proper cache invalidation.

## Key Changes
- Incremented cache version from `fabricbom-v1` to `fabricbom-v2` to force cache refresh
- Added 8 new product pages to the SHELL cache list:
  - `fortiappsec-bomgen.html`
  - `forticnapp-bomgen.html`
  - `fortidlp-bomgen.html`
  - `fortiextender-bomgen.html`
  - `fortimail-bomgen.html`
  - `fortimail-workspace-bomgen.html`
  - `fortipresence-bomgen.html`
  - `fortirecon-bomgen.html`

## Implementation Details
These new product pages are now included in the service worker's pre-cache list, ensuring they are available for offline access and improving load performance for users with cached assets.

https://claude.ai/code/session_01WabAnPE8Xdww2WEd9EScPD