### PR TITLE
Fix Save/Export dropdown missing CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,8 +220,8 @@
   }
 
   /* Copy/Export dropdown menu */
-  #copy-menu{display:none;position:fixed;background:#fff;border:1px solid var(--c-border);border-radius:4px;box-shadow:0 6px 20px rgba(0,0,0,.15);min-width:196px;z-index:600;overflow:hidden;padding:4px 0;}
-  #copy-menu.on{display:block;}
+  #copy-menu,#project-menu{display:none;position:fixed;background:#fff;border:1px solid var(--c-border);border-radius:4px;box-shadow:0 6px 20px rgba(0,0,0,.15);min-width:196px;z-index:600;overflow:hidden;padding:4px 0;}
+  #copy-menu.on,#project-menu.on{display:block;}
   .dm-section{font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:.09em;color:var(--c-textm);padding:6px 12px 2px;}
   .dm-item{display:flex;align-items:center;gap:8px;padding:7px 12px;font-size:12px;color:var(--c-text);cursor:pointer;white-space:nowrap;font-family:inherit;background:none;border:none;width:100%;text-align:left;}
   .dm-item:hover{background:var(--c-sh);}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `#project-menu` was missing `display:none` and `position:fixed` CSS rules, causing it to render visibly at the bottom of the page instead of as a hidden dropdown
- Extended the existing `#copy-menu` CSS selectors to include `#project-menu` so both menus share the same base styles

## Test plan

- [ ] Click "Save / Export" button — dropdown appears directly below the button
- [ ] Click "Save Project", "Export CSV", "Import CSV" menu items — each action fires correctly and menu closes
- [ ] Click outside the open dropdown — menu closes
- [ ] Verify "Copy / Export" dropdown still works independently

https://claude.ai/code/session_01DVpSmyf9tHHT41hoDHYhUj
EOF
)