### PR TITLE
Refine Project BOM action buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -1123,12 +1123,13 @@ async function toggleProjectMenu(e) {
   e.stopPropagation();
   const menu = document.getElementById('project-menu');
   if (menu.classList.contains('on')) { menu.classList.remove('on'); return; }
+  const btn = e.currentTarget;
   try {
     const pricing = await getPricingIDB();
     const sfdc = document.getElementById('project-sfdc-section');
     if (sfdc) sfdc.style.display = (pricing && pricing.rows && pricing.rows.length) ? '' : 'none';
   } catch(_) {}
-  const rect = e.currentTarget.getBoundingClientRect();
+  const rect = btn.getBoundingClientRect();
   menu.style.top  = (rect.bottom + 4) + 'px';
   menu.style.left = rect.left + 'px';
   menu.classList.add('on');


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Save / Export button** is now red (`.bp` / Fortinet red `#EE3124`) to make it stand out from the other action buttons
- **SFDC Export (Download CSV)** section moved from the Copy/Share dropdown into the Save / Export dropdown (below the FILE section), and is only visible when pricing data is loaded in IndexedDB (`fabricbom-pricing`)
- **Copy / Export** button renamed to **Copy / Share** to eliminate the confusing duplicate "Export" label
- **Bug fix**: Save / Export dropdown was not appearing in any browser — `e.currentTarget` becomes `null` after an `await`, so it is now captured before the async pricing check

## Test plan

- [ ] Click **Save / Export** — confirm button is red and dropdown appears with Project, File sections
- [ ] With no pricing loaded: confirm SFDC Export section is absent from the dropdown
- [ ] With pricing loaded: confirm SFDC Export section appears below FILE, and each region export works
- [ ] Click **Copy / Share** — confirm label is updated and all copy/share items still function
- [ ] Verify in Firefox, Chrome, and Mobile Safari

https://claude.ai/code/session_01YMG4QW8s4DUK63aXPNhqas
EOF
)