### PR TITLE
Fix BOM table full-width gap and row striping regressions

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@
 
   /* BOM table */
   .bt-wrap{overflow-x:auto;-webkit-overflow-scrolling:touch;}
-  table.bt{width:100%;border-collapse:collapse;font-size:12px;table-layout:fixed;min-width:580px;}
+  table.bt{width:100%;border-collapse:collapse;font-size:12px;min-width:580px;}
   table.bt thead th{background:var(--c-th);border:1px solid var(--c-border);padding:6px 10px;text-align:left;font-weight:700;font-size:10px;text-transform:uppercase;letter-spacing:.05em;color:#4A5268;white-space:nowrap;}
   table.bt tbody td{border:1px solid var(--c-border);padding:6px 10px;vertical-align:top;font-size:12px;}
   table.bt tbody tr.bt-even td{background:var(--c-sh);}
@@ -162,7 +162,7 @@
   @media (max-width:640px) {
     .col-notes{display:none;}
     .col-exp{display:table-cell;width:28px;padding:2px 4px!important;}
-    table.bt{min-width:0;table-layout:auto;}
+    table.bt{min-width:0;}
   }
   @media (max-width:480px) {
     .col-type{display:none;}


### PR DESCRIPTION
## Summary

Follow-up fixes for two regressions introduced by the mobile column-hiding feature:

- **Full-width gap**: `table-layout:fixed` treated the hidden `col-exp` `<th>` as a flex-width column and reserved a share of remaining space for it, leaving a visible gap on the right side of data rows. Removed `table-layout:fixed` so the browser uses `auto` layout, which truly excludes `display:none` columns and lets Description fill all available space.
- **Broken row striping**: `tr:nth-child(even)` counted the hidden `.bom-detail` rows in the DOM, placing all data rows at odd positions so the alternating background never applied. Replaced with a JS counter that stamps a `bt-even` class on every second data row.

## Test plan

- [ ] On desktop: data rows span the full width of the table (matching the section header rows)
- [ ] Row colors alternate correctly — every other data row has the shaded background
- [ ] Section divider rows still span full width
- [ ] Mobile column hiding and + expand button still work as expected

https://claude.ai/code/session_01Fz8TPb41xyWQqnY5duYtw9