### PR TITLE
Widen breakpoints for BOM column hiding

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,15 +159,15 @@
   .det-tbl tr+tr td{border-top:1px solid var(--c-border);}
   .det-k{font-weight:700;font-size:10px;text-transform:uppercase;letter-spacing:.04em;color:var(--c-text2);padding:3px 10px 3px 0;width:90px;white-space:nowrap;vertical-align:top;}
   .det-v{color:var(--c-text);vertical-align:top;padding:3px 0;}
-  @media (max-width:640px) {
+  @media (max-width:999px) {
     .col-notes{display:none;}
     .col-exp{display:table-cell;width:28px;padding:2px 4px!important;}
     table.bt{min-width:0;}
   }
-  @media (max-width:480px) {
+  @media (max-width:849px) {
     .col-type{display:none;}
   }
-  @media (max-width:360px) {
+  @media (max-width:649px) {
     .col-desc{display:none;}
   }
 


### PR DESCRIPTION
## Summary

Adjusted the viewport breakpoints at which BOM table columns are hidden to trigger earlier, keeping the table readable on a wider range of screen sizes.

| Column | Before | After |
|---|---|---|
| Notes | < 640px | < 1000px |
| Type | < 480px | < 850px |
| Description | < 360px | < 650px |

The **+** expand button (which reveals hidden column data inline) appears whenever Notes is hidden, so it now shows at < 1000px as well.

## Test plan

- [ ] At 999px wide: Notes hidden, + button visible; Part Number, Description, Qty, Type all visible
- [ ] At 849px wide: Type also hidden
- [ ] At 649px wide: Description also hidden; only Part Number and Qty remain
- [ ] Above 1000px: all columns visible, no + button

https://claude.ai/code/session_01Fz8TPb41xyWQqnY5duYtw9