### PR TITLE
Fix Notes column width and enforce consistent column widths with table-layout:fixed

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@
 
   /* BOM table */
   .bt-wrap{overflow-x:auto;-webkit-overflow-scrolling:touch;}
-  table.bt{width:100%;border-collapse:collapse;font-size:12px;min-width:580px;}
+  table.bt{width:100%;border-collapse:collapse;font-size:12px;min-width:580px;table-layout:fixed;}
   table.bt thead th{background:var(--c-th);border:1px solid var(--c-border);padding:6px 10px;text-align:left;font-weight:700;font-size:10px;text-transform:uppercase;letter-spacing:.05em;color:#4A5268;white-space:nowrap;}
   table.bt tbody td{border:1px solid var(--c-border);padding:6px 10px;vertical-align:top;font-size:12px;}
   table.bt tbody tr.bt-even td{background:var(--c-sh);}
@@ -150,8 +150,8 @@
   .br-m{background:#FFF8EE;color:#8A5800;border:1px solid #F5D9A0;}
 
   /* Responsive column hiding for BOM table */
-  .col-exp{display:none;padding:0!important;text-align:center;}
-  .col-desc{min-width:450px;width:100%;}
+  .col-exp{visibility:hidden;width:0;max-width:0;overflow:hidden;padding:0!important;border-width:0!important;}
+  .col-desc{min-width:450px;}
   .exp-btn{background:none;border:1px solid var(--c-ib);border-radius:2px;color:var(--c-text2);font-size:13px;font-weight:700;width:20px;height:20px;line-height:1;cursor:pointer;padding:0;font-family:inherit;transition:background .12s,color .12s;}
   .exp-btn:hover,.exp-btn.open{background:var(--forti-red);color:#fff;border-color:var(--forti-red);}
   .bom-detail{display:none;}
@@ -162,7 +162,7 @@
   .det-v{color:var(--c-text);vertical-align:top;padding:3px 0;}
   @media (max-width:999px) {
     .col-notes{display:none;}
-    .col-exp{display:table-cell;width:28px;padding:2px 4px!important;}
+    .col-exp{visibility:visible;width:28px;max-width:28px;overflow:visible;padding:2px 4px!important;border-width:1px!important;}
     table.bt{min-width:0;}
   }
   @media (max-width:849px) {


### PR DESCRIPTION
## Summary

- Re-adds `table-layout:fixed` to enforce hard column widths across all product group tables — previously `table-layout:auto` treated `width:125px` on Notes as a hint only, allowing content to override it per-table
- Switches the expand column from `display:none` to `visibility:hidden` + `width:0` on desktop — `display:none` removes the element from the rendering tree so the fixed layout algorithm treated it as an unconstrained flex column and stole space; `visibility:hidden` keeps it in the layout so `width:0` is enforced, while `border-width:0` and `overflow:hidden` ensure nothing bleeds through
- On mobile (< 999px) the expand column is restored to `visibility:visible; width:28px` for the + button

## Test plan

- [ ] Notes column is consistently 125px wide across all product groups regardless of notes content length
- [ ] Data rows span the full width of the table on desktop
- [ ] Column headers align across multiple product group tables
- [ ] Mobile column hiding and + expand button still work at the defined breakpoints

https://claude.ai/code/session_01Fz8TPb41xyWQqnY5duYtw9