### PR TITLE
Tighten mobile breakpoints — column hiding starts at &lt;550px

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,15 +160,15 @@
   .det-tbl tr+tr td{border-top:1px solid var(--c-border);}
   .det-k{font-weight:700;font-size:10px;text-transform:uppercase;letter-spacing:.04em;color:var(--c-text2);padding:3px 10px 3px 0;width:90px;white-space:nowrap;vertical-align:top;}
   .det-v{color:var(--c-text);vertical-align:top;padding:3px 0;}
-  @media (max-width:999px) {
+  @media (max-width:549px) {
     .col-notes{display:none;}
     .col-exp{visibility:visible;width:28px;max-width:28px;overflow:visible;padding:2px 4px!important;border-width:1px!important;}
     table.bt{min-width:0;}
   }
-  @media (max-width:849px) {
+  @media (max-width:449px) {
     .col-type{display:none;}
   }
-  @media (max-width:649px) {
+  @media (max-width:379px) {
     .col-desc{display:none;}
   }
 


### PR DESCRIPTION
## Summary

Tightened all mobile column-hiding breakpoints so they only activate on small phone screens:

| Column | Before | After |
|---|---|---|
| Notes + expand button | < 1000px | < 550px |
| Type | < 850px | < 450px |
| Description | < 650px | < 380px |

All breakpoints are kept in sync so the + expand button is always visible whenever any column is hidden — there's no gap where data would be inaccessible.

## Test plan

- [ ] Above 550px: all columns visible, no + button
- [ ] At 549px: Notes hidden, + button appears
- [ ] At 449px: Type also hidden
- [ ] At 379px: Description also hidden, only Part Number and Qty remain
- [ ] Clicking + shows all hidden fields in the detail panel

https://claude.ai/code/session_01Fz8TPb41xyWQqnY5duYtw9