### PR TITLE
Update mobile breakpoints — Notes &lt;650px, Type &lt;625px, Description &lt;600px

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,15 +160,15 @@
   .det-tbl tr+tr td{border-top:1px solid var(--c-border);}
   .det-k{font-weight:700;font-size:10px;text-transform:uppercase;letter-spacing:.04em;color:var(--c-text2);padding:3px 10px 3px 0;width:90px;white-space:nowrap;vertical-align:top;}
   .det-v{color:var(--c-text);vertical-align:top;padding:3px 0;}
-  @media (max-width:549px) {
+  @media (max-width:649px) {
     .col-notes{display:none;}
     .col-exp{visibility:visible;width:28px;max-width:28px;overflow:visible;padding:2px 4px!important;border-width:1px!important;}
     table.bt{min-width:0;}
   }
-  @media (max-width:449px) {
+  @media (max-width:624px) {
     .col-type{display:none;}
   }
-  @media (max-width:379px) {
+  @media (max-width:599px) {
     .col-desc{display:none;}
   }
 


### PR DESCRIPTION
## Summary

Updated mobile column-hiding breakpoints:

| Column | Before | After |
|---|---|---|
| Notes + expand button | < 550px | < 650px |
| Type | < 450px | < 625px |
| Description | < 380px | < 600px |

## Test plan

- [ ] Above 650px: all columns visible, no + button
- [ ] At 649px: Notes hidden, + button appears
- [ ] At 624px: Type also hidden
- [ ] At 599px: Description also hidden, only Part Number and Qty remain
- [ ] Clicking + shows all hidden fields in the detail panel

https://claude.ai/code/session_01Fz8TPb41xyWQqnY5duYtw9