### PR TITLE
Clamp Description and Notes columns to 3 lines with hover tooltip

### DIFF
--- a/index.html
+++ b/index.html
@@ -810,7 +810,7 @@ async function renderGroups() {
         const expCell = detailRows.length ? `<td class="col-exp"><button class="exp-btn" onclick="toggleDetail(this)" title="Show details">+</button></td>` : `<td class="col-exp"></td>`;
         const detailTr = detailRows.length ? `<tr class="bom-detail"><td colspan="100"><table class="det-tbl"><tbody>${detailRows.join('')}</tbody></table></td></tr>` : '';
         const evenCls = lines%2===0 ? ' class="bt-even"' : '';
-        return `<tr${evenCls}><td><span class="sk">${h(r.sku||'')}</span></td><td class="nc col-desc">${h(r.desc||'')}</td><td class="qc">${r.qty??''}</td><td class="col-type">${bm[r.kind]||''}</td><td class="nc col-notes"><span class="note-clamp" title="${h(r.note||'')}">${h(r.note||'')}</span></td>${priceCells}${expCell}</tr>${detailTr}`;
+        return `<tr${evenCls}><td><span class="sk">${h(r.sku||'')}</span></td><td class="nc col-desc"><span class="note-clamp" title="${h(r.desc||'')}">${h(r.desc||'')}</span></td><td class="qc">${r.qty??''}</td><td class="col-type">${bm[r.kind]||''}</td><td class="nc col-notes"><span class="note-clamp" title="${h(r.note||'')}">${h(r.note||'')}</span></td>${priceCells}${expCell}</tr>${detailTr}`;
       }).join('');
       totL+=lines; totQ+=qty;
       const el = document.createElement('div');


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds a `.note-clamp` CSS class using `-webkit-line-clamp: 3` to restrict long text to a maximum of 3 lines with an ellipsis for overflow
- Applies the clamp to both the **Notes** and **Description** columns in the Project BOM table
- Wraps each cell's content in a `<span>` with a `title` attribute so hovering reveals the full, untruncated text

## Test plan

- [ ] Add a BOM item with a long description (>3 lines) and verify it is clamped with an ellipsis
- [ ] Add a BOM item with a long note (>3 lines) and verify it is clamped with an ellipsis
- [ ] Hover over a clamped cell and confirm the full text appears in the browser tooltip
- [ ] Verify short text (≤3 lines) renders normally with no clipping
- [ ] Check on mobile breakpoints that the Notes column still hides correctly (<650px)

https://claude.ai/code/session_01YKdWRJ4EDX9xXcjLLovms4
EOF
)