### PR TITLE
Fix CSV import: quote-aware line splitting handles commas in quoted fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -1520,7 +1520,22 @@ function parsePricingLine(line) {
 }
 
 function parsePricingCSV(text) {
-  const rawLines = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n');
+  // Split into logical CSV lines respecting quoted fields that may contain newlines
+  const rawLines = [];
+  const normalized = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  let lineBuf = '', inQ = false;
+  for (let i = 0; i < normalized.length; i++) {
+    const c = normalized[i];
+    if (c === '"') {
+      if (inQ && normalized[i + 1] === '"') { lineBuf += '""'; i++; }
+      else { inQ = !inQ; lineBuf += c; }
+    } else if (c === '\n' && !inQ) {
+      rawLines.push(lineBuf); lineBuf = '';
+    } else {
+      lineBuf += c;
+    }
+  }
+  rawLines.push(lineBuf);
   let name = '', effectiveDate = '', headerRowIdx = -1, foundDate = false;
 
   for (let i = 0; i < Math.min(rawLines.length, 30); i++) {


### PR DESCRIPTION
Replaces naive split('\n') in parsePricingCSV with a character-by-character
pass that tracks open quotes, so quoted fields containing newlines (and the
commas within them) are kept on one logical line before parsePricingLine
processes them.

https://claude.ai/code/session_01BVYXiHbzQPVDW86VHgmNZ4