### PR TITLE
Increase SKU entry table quantity column width

### DIFF
--- a/products/custom-sku-bomgen.html
+++ b/products/custom-sku-bomgen.html
@@ -176,7 +176,7 @@ input.sku-input {
 .sku-entry-table colgroup col.col-num   { width: 28px; }
 .sku-entry-table colgroup col.col-sku   { width: 175px; }
 .sku-entry-table colgroup col.col-desc  { width: auto; }
-.sku-entry-table colgroup col.col-qty   { width: 62px; }
+.sku-entry-table colgroup col.col-qty   { width: 80px; }
 .sku-entry-table colgroup col.col-type  { width: 110px; }
 .sku-entry-table colgroup col.col-notes { width: 170px; }
 .sku-entry-table colgroup col.col-del   { width: 36px; }


### PR DESCRIPTION
## Summary
Adjusted the width of the quantity column in the SKU entry table to improve usability and accommodate larger input values.

## Changes
- Increased `.sku-entry-table colgroup col.col-qty` width from 62px to 80px

## Details
This change provides additional horizontal space for the quantity column in the custom SKU BOM generator table, allowing for better visibility and easier interaction with quantity input fields.

https://claude.ai/code/session_01XyB7VYHgPG4RUjpPXpSqRz