### PR TITLE
Make quantity fields editable in BOM table

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,6 +143,11 @@
   .sr td{background:#EAECF3!important;font-weight:700;font-size:10px;text-transform:uppercase;letter-spacing:.06em;color:var(--c-text2);padding:4px 10px;border-top:2px solid #C5CAD9;}
   .sk{font-family:'Courier New',monospace;font-size:11px;color:#1A4E82;font-weight:700;white-space:nowrap;}
   .qc{text-align:center;font-weight:700;color:var(--c-textm);}
+  .qty-input{width:44px;text-align:center;border:1px solid transparent;border-radius:3px;background:transparent;font-size:12px;font-weight:700;color:var(--c-textm);font-family:inherit;padding:1px 3px;-moz-appearance:textfield;}
+  .qty-input:hover{border-color:var(--c-border);}
+  .qty-input:focus{border-color:#4A90D9;outline:none;background:#fff;}
+  .qty-input::-webkit-inner-spin-button,.qty-input::-webkit-outer-spin-button{opacity:0;}
+  .qty-input:hover::-webkit-inner-spin-button,.qty-input:focus::-webkit-inner-spin-button{opacity:1;}
   .nc{color:var(--c-textm);font-size:11px;}
   .br{display:inline-block;font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:.05em;border-radius:2px;padding:1px 4px;}
   .br-r{background:#FEE0DE;color:#C0392B;border:1px solid #F5C6C2;}
@@ -753,6 +758,14 @@ function toggleDetail(btn) {
   btn.classList.toggle('open', !open);
   btn.textContent = open ? '+' : '−';
 }
+function updateQty(entryId, rowIdx, rawVal) {
+  const entry = cart.find(e => e.id === entryId);
+  if (!entry) return;
+  const num = parseInt(rawVal, 10);
+  entry.rows[rowIdx].qty = (rawVal === '' || rawVal === null) ? undefined : (!isNaN(num) && num >= 0 ? num : entry.rows[rowIdx].qty);
+  saveCart();
+  renderGroups();
+}
 function clearCart() { if (!confirm('Clear all items from the Project BOM?')) return; cart=[]; seq=0; if (location.hash.startsWith('#bom=')) history.replaceState(null, '', location.pathname); updateBadges(); renderGroups(); saveCart(); }
 
 // ── RENDER ───────────────────────────────────────────────────────────────────
@@ -804,7 +817,7 @@ async function renderGroups() {
     } else {
       let lines=0, qty=0;
       const displayRows = rowsWithTerm(entry.rows);
-      const rows = displayRows.map(r => {
+      const rows = displayRows.map((r, i) => {
         if (r.section!==undefined) return `<tr class="sr"><td colspan="${colSpan}">${h(r.section)}</td></tr>`;
         lines++; if (typeof r.qty==='number') qty+=r.qty;
         const bm={req:'<span class="br br-r">Required</span>',mand:'<span class="br br-m">Mandatory</span>',opt:'<span class="br br-o">Optional</span>',inc:'<span class="br br-o">Included</span>',note:''};
@@ -823,7 +836,7 @@ async function renderGroups() {
         const expCell = detailRows.length ? `<td class="col-exp"><button class="exp-btn" onclick="toggleDetail(this)" title="Show details">+</button></td>` : `<td class="col-exp"></td>`;
         const detailTr = detailRows.length ? `<tr class="bom-detail"><td colspan="100"><table class="det-tbl"><tbody>${detailRows.join('')}</tbody></table></td></tr>` : '';
         const evenCls = lines%2===0 ? ' class="bt-even"' : '';
-        return `<tr${evenCls}><td><span class="sk">${h(r.sku||'')}</span></td><td class="nc col-desc"><span class="note-clamp" title="${h(r.desc||'')}">${h(r.desc||'')}</span></td><td class="qc">${r.qty??''}</td><td class="col-type">${bm[r.kind]||''}</td><td class="nc col-notes"><span class="note-clamp" title="${h(r.note||'')}">${h(r.note||'')}</span></td>${priceCells}${expCell}</tr>${detailTr}`;
+        return `<tr${evenCls}><td><span class="sk">${h(r.sku||'')}</span></td><td class="nc col-desc"><span class="note-clamp" title="${h(r.desc||'')}">${h(r.desc||'')}</span></td><td class="qc"><input type="number" class="qty-input" value="${r.qty??''}" min="0" onchange="updateQty(${entry.id},${i},this.value)"></td><td class="col-type">${bm[r.kind]||''}</td><td class="nc col-notes"><span class="note-clamp" title="${h(r.note||'')}">${h(r.note||'')}</span></td>${priceCells}${expCell}</tr>${detailTr}`;
       }).join('');
       totL+=lines; totQ+=qty;
       const el = document.createElement('div');


### PR DESCRIPTION
## Summary
This change adds inline editing capability for quantity values in the Bill of Materials (BOM) table, allowing users to modify quantities directly without leaving the page.

## Key Changes
- **New CSS styles** for `.qty-input` class:
  - Styled number input with transparent background and minimal borders
  - Hover state shows border for better UX
  - Focus state highlights input with blue border and white background
  - Hides spinner buttons by default, shows them on hover/focus for webkit browsers

- **New `updateQty()` function**:
  - Handles quantity updates when user changes the input value
  - Validates input: accepts non-negative integers or clears the field if empty
  - Reverts to previous value if invalid input is provided
  - Automatically saves cart and re-renders the BOM after update

- **Updated BOM row rendering**:
  - Changed quantity cell from static text to editable `<input type="number">` element
  - Captures row index in map callback to pass to `updateQty()` handler
  - Input includes min="0" constraint and onchange event binding

## Implementation Details
- The quantity input maintains the existing value display while allowing inline editing
- Invalid inputs (negative numbers, non-numeric values) are silently rejected and reverted
- Empty input is treated as clearing the quantity (undefined state)
- Changes persist via the existing `saveCart()` mechanism

https://claude.ai/code/session_01X7y2aMWcUnk8QLzUQ26JhJ