### PR TITLE
Simplify BOM item labeling by removing run counter logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -749,13 +749,11 @@ function showAbout() {
 window.addEventListener('message', e => {
   if (!e.data || e.data.type !== 'FORTIBOM_ADD') return;
   const { product, label, rows, meta } = e.data;
-  const count = cart.filter(c => c.product === product).length;
-  const dispLabel = count > 0 ? `${label} (run ${count+1})` : label;
-  cart.push({ id:++seq, product, label:dispLabel, rows, meta });
+  cart.push({ id:++seq, product, label, rows, meta });
   updateBadges();
   renderGroups();
   saveCart();
-  toast(`✓ Added to Project BOM: ${dispLabel}`);
+  toast(`✓ Added to Project BOM: ${label}`);
   if (cart.length === 1) showPBV();
 });
 


### PR DESCRIPTION
## Summary
Removed the automatic run counter logic from BOM item labels. Items are now added to the cart with their original label instead of appending a run number suffix.

## Key Changes
- Removed duplicate product detection and run counter calculation
- Simplified label handling to use the original label directly instead of appending `(run N)` suffix
- Updated toast notification to display the original label without the run counter

## Implementation Details
The previous implementation tracked how many times a product had been added to the cart and appended a run number to the label (e.g., "Product (run 2)"). This logic has been removed, streamlining the add-to-cart flow and reducing complexity. Items are now stored with their original labels, which may be more appropriate if run tracking should be handled differently or if duplicate products should be allowed without label modification.

https://claude.ai/code/session_018SokHy5RMk9rgRcQ5XuXvX