### PR TITLE
Hide project total when displaying empty state

### DIFF
--- a/index.html
+++ b/index.html
@@ -878,6 +878,7 @@ async function renderGroups() {
     c.innerHTML = '';
     ec.style.display = 'flex';
     sbar.style.display = 'none';
+    document.getElementById('project-total').style.display = 'none';
     return;
   }
   ec.style.display = 'none';


### PR DESCRIPTION
## Summary
This change hides the project total element when the empty state is displayed, ensuring a cleaner UI when there are no projects to show.

## Key Changes
- Added `document.getElementById('project-total').style.display = 'none';` to hide the project total element when rendering the empty state
- This line is executed in the same conditional block where the empty container is shown and the search bar is hidden

## Implementation Details
The project total element is now hidden alongside other UI adjustments when the empty state is triggered, maintaining visual consistency and preventing orphaned UI elements from appearing when there are no projects to display.

https://claude.ai/code/session_01WuXc37FyQvaSqG3Jo2Dnwj