### PR TITLE
Disable mobile pinch-to-zoom on index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
 <title>FabricBOM</title>
 <link rel="icon" type="image/x-icon" href="favicon.ico">
 <link rel="icon" type="image/png" sizes="192x192" href="icons/pwa-192x192.png">
@@ -26,7 +26,8 @@
     --c-ib:#C8CDD9; --c-th:#EEF1F6;
   }
   *{box-sizing:border-box;margin:0;padding:0;}
-  body{font-family:'Segoe UI','Helvetica Neue',Arial,sans-serif;background:var(--forti-dark);color:var(--forti-text-primary);height:100vh;overflow:hidden;display:flex;flex-direction:column;}
+  html{touch-action:pan-x pan-y;}
+  body{font-family:'Segoe UI','Helvetica Neue',Arial,sans-serif;background:var(--forti-dark);color:var(--forti-text-primary);height:100vh;overflow:hidden;display:flex;flex-direction:column;touch-action:pan-x pan-y;}
 
   /* TOP BAR */
   #top-bar{height:var(--hh);background:var(--forti-dark);border-bottom:1px solid var(--forti-border);display:flex;align-items:center;padding:0 20px;gap:16px;flex-shrink:0;z-index:200;}


### PR DESCRIPTION
Add user-scalable=no and maximum/minimum-scale=1.0 to the viewport meta tag,
and touch-action:pan-x pan-y on html/body to block pinch-zoom on iOS Safari
(which ignores user-scalable=no since iOS 10).

https://claude.ai/code/session_01GzNmtxn6ANUEQp4NtnS2wW