### PR TITLE
Hide additional menus in print view

### DIFF
--- a/index.html
+++ b/index.html
@@ -342,7 +342,7 @@
 
   @media print {
     body{background:#fff;overflow:auto;height:auto;}
-    #top-bar,#sidebar,#ch,.act-row,#toast,#pfw{display:none!important;}
+    #top-bar,#sidebar,#ch,.act-row,#toast,#pfw,#copy-menu,#project-menu,#add-menu{display:none!important;}
     #main{display:block;}
     #pbv{display:flex!important;overflow:visible;padding:20px;}
     .bg-del{display:none!important;}


### PR DESCRIPTION
## Summary
Updated the print media query to hide additional menu elements that should not appear when printing the page.

## Changes
- Added `#copy-menu`, `#project-menu`, and `#add-menu` to the list of elements hidden during print (`display:none!important`)
- These menus are now excluded from print output along with other UI chrome elements like the top bar, sidebar, and toast notifications

## Details
This ensures a cleaner print layout by hiding contextual menu elements that are only relevant for interactive use and would clutter a printed document.

https://claude.ai/code/session_01L1Pe3JwnYyNt1dtx76dxSa