### PR TITLE
Hide product tag for Custom SKU entries in cart

### DIFF
--- a/index.html
+++ b/index.html
@@ -1013,7 +1013,7 @@ async function renderGroups() {
             <svg width="12" height="18" viewBox="0 0 12 18" fill="none"><circle cx="4" cy="4" r="1.3" fill="currentColor"/><circle cx="8" cy="4" r="1.3" fill="currentColor"/><circle cx="4" cy="9" r="1.3" fill="currentColor"/><circle cx="8" cy="9" r="1.3" fill="currentColor"/><circle cx="4" cy="14" r="1.3" fill="currentColor"/><circle cx="8" cy="14" r="1.3" fill="currentColor"/></svg>
           </div>
           <div><input type="text" class="label-input bgp" value="${h(entry.label)}" onchange="updateEntryLabel(${entry.id},this.value)"><div class="bgm">${lines} line item${lines!==1?'s':''} · ${qty.toLocaleString()} units/licenses</div></div>
-          <span class="bg-tag">${h(entry.product)}</span>
+          ${entry.product !== 'Custom SKU' ? `<span class="bg-tag">${h(entry.product)}</span>` : ''}
           <button class="bg-del" onclick="removeFromCart(${entry.id})">✕</button>
         </div>
         <div class="bt-wrap"><table class="bt"><thead><tr>


### PR DESCRIPTION
## Summary
Modified the cart display logic to conditionally render the product tag, hiding it when the product is labeled as 'Custom SKU'.

## Changes
- Updated the product tag rendering in the cart entry template to check if `entry.product` is 'Custom SKU'
- When the product is 'Custom SKU', the tag is not displayed; otherwise, it renders as before
- Uses a ternary operator with template literals to conditionally include the span element

## Implementation Details
The change replaces the unconditional `<span class="bg-tag">${h(entry.product)}</span>` with a conditional expression: `${entry.product !== 'Custom SKU' ? `<span class="bg-tag">${h(entry.product)}</span>` : ''}`. This prevents the product tag from appearing in the UI for custom SKU items while maintaining the existing behavior for all other product types.

https://claude.ai/code/session_018935sxYgZxSsyEt6KQeTqG