### PR TITLE
Hide background actions in print view

### DIFF
--- a/index.html
+++ b/index.html
@@ -345,7 +345,7 @@
     #top-bar,#sidebar,#ch,.act-row,#toast,#pfw,#copy-menu,#project-menu,#add-menu{display:none!important;}
     #main{display:block;}
     #pbv{display:flex!important;overflow:visible;padding:20px;}
-    .bg-del{display:none!important;}
+    .bg-del,.bgr-actions{display:none!important;}
     .lc,.bg{break-inside:avoid;}
     .pi-edit-btn{display:none!important;}
     #proj-info-card .pfg{display:none!important;}


### PR DESCRIPTION
## Summary
Updated the print view CSS to hide the background actions element alongside other UI components that should not appear in printed output.

## Changes
- Modified the `.bg-del` CSS rule in the print media query to also hide `.bgr-actions` element
- This ensures the background actions component is not displayed when the page is printed or exported to PDF

## Details
The change adds `.bgr-actions` to the existing display:none rule for print styling, maintaining consistency with other hidden UI elements like the top bar, sidebar, and various menus that are already excluded from the print view.

https://claude.ai/code/session_01UPhZ8qAQpRBVcjykGhkAxV