### PR TITLE
Fix flex layout for cart entry labels to prevent text overflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -1012,7 +1012,7 @@ async function renderGroups() {
           <div class="drag-handle" title="Drag to reorder">
             <svg width="12" height="18" viewBox="0 0 12 18" fill="none"><circle cx="4" cy="4" r="1.3" fill="currentColor"/><circle cx="8" cy="4" r="1.3" fill="currentColor"/><circle cx="4" cy="9" r="1.3" fill="currentColor"/><circle cx="8" cy="9" r="1.3" fill="currentColor"/><circle cx="4" cy="14" r="1.3" fill="currentColor"/><circle cx="8" cy="14" r="1.3" fill="currentColor"/></svg>
           </div>
-          <div><input type="text" class="label-input bgp" value="${h(entry.label)}" onchange="updateEntryLabel(${entry.id},this.value)"><div class="bgm">${lines} line item${lines!==1?'s':''} · ${qty.toLocaleString()} units/licenses</div></div>
+          <div style="flex:1;min-width:0;"><input type="text" class="label-input bgp" value="${h(entry.label)}" onchange="updateEntryLabel(${entry.id},this.value)"><div class="bgm">${lines} line item${lines!==1?'s':''} · ${qty.toLocaleString()} units/licenses</div></div>
           ${entry.product !== 'Custom SKU' ? `<span class="bg-tag">${h(entry.product)}</span>` : ''}
           <button class="bg-del" onclick="removeFromCart(${entry.id})">✕</button>
         </div>


### PR DESCRIPTION
## Summary
Added flexbox styling to the cart entry label container to properly handle text overflow and ensure the input field and metadata text don't exceed their container bounds.

## Changes
- Added `style="flex:1;min-width:0;"` to the label container div in the cart entry template
  - `flex:1` allows the container to grow and fill available space
  - `min-width:0` enables proper text truncation for flex children, preventing overflow of the input field and metadata text

## Details
This fix addresses a layout issue where the label input and metadata text could overflow their container in the cart display. By applying these flexbox properties, the container now properly constrains its children and allows for appropriate text truncation when space is limited.

https://claude.ai/code/session_014Zhg5oNYHH8Tta9tjh1Axi