### PR TITLE
Fix SFDC CSV export: remove region hyphen and quotes, strip commas

### DIFF
--- a/index.html
+++ b/index.html
@@ -1607,7 +1607,7 @@ function exportSFDC(region) {
     if (!r.sku) continue;
     rows.push([`${r.sku}${region}`, r.qty??'', 28, r.note||'']);
   }
-  const csv = rows.map(r => r.map(c => `"${String(c).replace(/"/g,'""')}"`).join(',')).join('\r\n');
+  const csv = rows.map(r => r.map(c => String(c).replace(/,/g,'')).join(',')).join('\r\n');
   const a = document.createElement('a');
   a.href = URL.createObjectURL(new Blob([csv],{type:'text/csv;charset=utf-8;'}));
   a.download = `SFDC_${region}_${new Date().toISOString().slice(0,10)}.csv`;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Remove the `-` between SKU and region suffix in SFDC exports (e.g. `FG-90GAMER` instead of `FG-90G-AMER`)
- Remove double-quote wrapping from all CSV cells
- Strip commas from cell contents to keep the unquoted CSV well-formed

## Test plan

- [ ] Export SFDC-AMER, SFDC-EMEA, and SFDC-APAC CSVs and verify UIDs have no hyphen before the region suffix
- [ ] Confirm no double quotes appear around values in the exported file
- [ ] Add a note with a comma and verify it is stripped in the export

https://claude.ai/code/session_01Fo98GLBZApr64itTdXfhei
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fo98GLBZApr64itTdXfhei)_