### PR TITLE
Rebrand FortiBOM to FabricBOM and update version display

### DIFF
--- a/index.html
+++ b/index.html
@@ -385,7 +385,6 @@
     Project BOM
     <span id="cbadge">0</span>
   </button>
-  <span class="ver-badge">v1.0.1b</span>
 </div>
 
 <div id="sidebar-overlay" onclick="closeSidebar()"></div>
@@ -861,7 +860,7 @@ function showAbout() {
   document.getElementById('pf').style.display = 'none';
   const ws = document.getElementById('ws');
   ws.style.display = 'flex';
-  ws.querySelector('h2').textContent = 'FortiBOM v2.0';
+  ws.querySelector('h2').textContent = 'FabricBOM v1.0.1b';
   ws.querySelector('p').textContent = 'Cross-product Bill of Materials generator for Fortinet deployments. Build BOMs per product, then combine them into a Project BOM.';
   ws.querySelector('p').innerHTML += '<br><br>Disclaimer: FabricBOM is not an officially sanctioned Fortinet product. Always validate output against the official Fortinet product ordering guides.';
   ws.querySelector('p').innerHTML += '<br><br><a href="https://github.com/msalty/FortiBOM/issues" target="_blank" rel="noopener noreferrer">Report an issue on GitHub</a>';


### PR DESCRIPTION
## Summary
This PR updates the application branding from "FortiBOM" to "FabricBOM" and adjusts the version display strategy by removing the inline version badge and updating the welcome screen version text.

## Key Changes
- Removed the inline version badge (`v1.0.1b`) from the sidebar header
- Updated the welcome screen heading from "FortiBOM v2.0" to "FabricBOM v1.0.1b"
- Version information is now displayed only in the welcome modal rather than in the persistent UI

## Implementation Details
The changes consolidate version display to a single location (the welcome screen modal) rather than showing it in multiple places. This simplifies the UI while maintaining version visibility when users access the about/welcome information.

https://claude.ai/code/session_01L4yVfmGNeWhrc3d8rhCf7X