### PR TITLE
Fix price formatting in BOM display and CSV import

### DIFF
--- a/index.html
+++ b/index.html
@@ -1122,7 +1122,8 @@ async function renderGroups() {
           const totalNum = (!isNaN(listPriceNum) && typeof r.qty === 'number') ? listPriceNum * r.qty : NaN;
           if (!isExcluded && !isNaN(totalNum)) { grandTotal += totalNum; grandTotalValid = true; }
           const totalDisplay = isExcluded ? '$0.00' : (!isNaN(totalNum) ? '$'+totalNum.toLocaleString('en-US',{minimumFractionDigits:2,maximumFractionDigits:2}) : '');
-          priceCells = `<td class="nc" style="text-align:right;white-space:nowrap;">${listPrice ? h(listPrice) : ''}</td><td class="nc" style="text-align:right;white-space:nowrap;">${totalDisplay}</td>`;
+          const listPriceDisplay = !isNaN(listPriceNum) ? '$'+listPriceNum.toLocaleString('en-US',{minimumFractionDigits:2,maximumFractionDigits:2}) : '';
+          priceCells = `<td class="nc" style="text-align:right;white-space:nowrap;">${listPriceDisplay}</td><td class="nc" style="text-align:right;white-space:nowrap;">${totalDisplay}</td>`;
         }
         const detailRows = [];
         if (r.desc) detailRows.push(`<tr><td class="det-k">Description</td><td class="det-v nc">${h(r.desc)}</td></tr>`);
@@ -2084,7 +2085,12 @@ function parsePricingCSV(text) {
     const cells = parsePricingLine(rawLines[i]);
     if (cells.every(c => !c.trim())) continue;
     const row = {};
-    headers.forEach((hdr, idx) => { if (hdr) row[hdr] = (cells[idx] || '').trim(); });
+    headers.forEach((hdr, idx) => {
+      if (!hdr) return;
+      let val = (cells[idx] || '').trim();
+      if (hdr === 'Price') val = val.replace(/[^0-9.]/g, '');
+      row[hdr] = val;
+    });
     rows.push(row);
   }
 


### PR DESCRIPTION
## Summary
This PR fixes price display and parsing issues in the FabricBOM application to ensure consistent currency formatting and proper numeric handling.

## Key Changes
- **Price display formatting**: Modified the list price cell rendering to format numeric prices with currency symbol and proper decimal places, instead of displaying the raw price string. This ensures prices are consistently formatted as currency (e.g., "$1,234.56") in the BOM table.

- **CSV price import parsing**: Enhanced the pricing line parser to strip non-numeric characters (except decimal points) from the "Price" column during CSV import. This allows the application to correctly parse prices that may contain currency symbols or other formatting characters from the source data.

## Implementation Details
- The list price display now uses `toLocaleString()` with fixed 2 decimal places, matching the formatting already applied to the total price column
- Price parsing during CSV import uses a regex replacement (`/[^0-9.]/g`) to remove all characters except digits and decimal points, ensuring clean numeric values are stored
- Both changes maintain backward compatibility while improving data consistency and user experience

https://claude.ai/code/session_01XzYJ7hBJmxc4sBT5VhBhgS