### PR TITLE
Bump service worker cache version to v3.0.0.5

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'fabricbom-v3.0.0.4';
+const CACHE = 'fabricbom-v3.0.0.5';
 
 const SHELL = [
   './',


### PR DESCRIPTION
## Summary
Updated the service worker cache version identifier to trigger a cache refresh for all users.

## Key Changes
- Incremented `CACHE` constant from `'fabricbom-v3.0.0.4'` to `'fabricbom-v3.0.0.5'` in `sw.js`

## Details
This cache version bump ensures that users will download the latest version of cached assets on their next visit. The service worker will treat this as a new cache, allowing old cached resources to be replaced with updated versions.

https://claude.ai/code/session_01EfQ1jCZqC95qCFDSZhytfs