### PR TITLE
Format list price display with currency formatting

### DIFF
--- a/index.html
+++ b/index.html
@@ -1122,7 +1122,8 @@ async function renderGroups() {
           const totalNum = (!isNaN(listPriceNum) && typeof r.qty === 'number') ? listPriceNum * r.qty : NaN;
           if (!isExcluded && !isNaN(totalNum)) { grandTotal += totalNum; grandTotalValid = true; }
           const totalDisplay = isExcluded ? '$0.00' : (!isNaN(totalNum) ? '$'+totalNum.toLocaleString('en-US',{minimumFractionDigits:2,maximumFractionDigits:2}) : '');
-          priceCells = `<td class="nc" style="text-align:right;white-space:nowrap;">${listPrice ? h(listPrice) : ''}</td><td class="nc" style="text-align:right;white-space:nowrap;">${totalDisplay}</td>`;
+          const listPriceDisplay = !isNaN(listPriceNum) ? '$'+listPriceNum.toLocaleString('en-US',{minimumFractionDigits:2,maximumFractionDigits:2}) : (listPrice ? h(listPrice) : '');
+          priceCells = `<td class="nc" style="text-align:right;white-space:nowrap;">${listPriceDisplay}</td><td class="nc" style="text-align:right;white-space:nowrap;">${totalDisplay}</td>`;
         }
         const detailRows = [];
         if (r.desc) detailRows.push(`<tr><td class="det-k">Description</td><td class="det-v nc">${h(r.desc)}</td></tr>`);


### PR DESCRIPTION
## Summary
Updated the list price display in the BOM table to consistently format numeric prices with currency symbols and proper decimal places, matching the formatting applied to the total price column.

## Key Changes
- Added `listPriceDisplay` variable that formats numeric list prices with `toLocaleString()` to display as currency (e.g., "$1,234.56")
- Falls back to HTML-escaped raw list price text if the price is not a valid number
- Updated the price cell HTML to use the formatted `listPriceDisplay` instead of conditionally displaying the raw `listPrice`

## Implementation Details
The change ensures that when a list price is successfully parsed as a number (`listPriceNum`), it is displayed with:
- Dollar sign prefix
- Thousands separators (commas)
- Exactly 2 decimal places

This provides a consistent user experience where both list price and total price columns display in the same professional currency format.

https://claude.ai/code/session_0115WZxBi7bMY3XivdqhSxqA