### PR TITLE
Migrate pricing database to shared toolbox schema

### DIFF
--- a/products/custom-sku-bomgen-mobile.html
+++ b/products/custom-sku-bomgen-mobile.html
@@ -1219,8 +1219,12 @@ let _pricingLoaded = false;
 function openPricingDB() {
   if (_pricingDb) return Promise.resolve(_pricingDb);
   return new Promise((resolve, reject) => {
-    const req = indexedDB.open('fabricbom_pricing', 1);
-    req.onupgradeneeded = e => e.target.result.createObjectStore('pricing');
+    const req = indexedDB.open('toolbox_shared', 2);
+    req.onupgradeneeded = e => {
+      const db = e.target.result;
+      if (db.objectStoreNames.contains('datasets')) db.deleteObjectStore('datasets');
+      db.createObjectStore('datasets', { keyPath: 'key' });
+    };
     req.onsuccess = e => { _pricingDb = e.target.result; resolve(_pricingDb); };
     req.onerror   = e => reject(e.target.error);
   });
@@ -1230,15 +1234,15 @@ async function getPricingData() {
   if (_pricingLoaded) return _pricingCache;
   try {
     const db = await openPricingDB();
-    const data = await new Promise((resolve, reject) => {
-      const tx = db.transaction('pricing', 'readonly');
-      const req = tx.objectStore('pricing').get('current');
+    const record = await new Promise((resolve, reject) => {
+      const tx = db.transaction('datasets', 'readonly');
+      const req = tx.objectStore('datasets').get('pricing');
       req.onsuccess = e => resolve(e.target.result || null);
       req.onerror   = e => reject(e.target.error);
     });
-    _pricingCache  = data;
+    _pricingCache  = record ? record.data : null;
     _pricingLoaded = true;
-    return data;
+    return _pricingCache;
   } catch(e) {
     _pricingLoaded = true;
     _pricingCache  = null;

--- a/products/custom-sku-bomgen.html
+++ b/products/custom-sku-bomgen.html
@@ -1046,8 +1046,12 @@ let _pricingLoaded = false;
 function openPricingDB() {
   if (_pricingDb) return Promise.resolve(_pricingDb);
   return new Promise((resolve, reject) => {
-    const req = indexedDB.open('fabricbom_pricing', 1);
-    req.onupgradeneeded = e => e.target.result.createObjectStore('pricing');
+    const req = indexedDB.open('toolbox_shared', 2);
+    req.onupgradeneeded = e => {
+      const db = e.target.result;
+      if (db.objectStoreNames.contains('datasets')) db.deleteObjectStore('datasets');
+      db.createObjectStore('datasets', { keyPath: 'key' });
+    };
     req.onsuccess = e => { _pricingDb = e.target.result; resolve(_pricingDb); };
     req.onerror = e => reject(e.target.error);
   });
@@ -1057,15 +1061,15 @@ async function getPricingData() {
   if (_pricingLoaded) return _pricingCache;
   try {
     const db = await openPricingDB();
-    const data = await new Promise((resolve, reject) => {
-      const tx = db.transaction('pricing', 'readonly');
-      const req = tx.objectStore('pricing').get('current');
+    const record = await new Promise((resolve, reject) => {
+      const tx = db.transaction('datasets', 'readonly');
+      const req = tx.objectStore('datasets').get('pricing');
       req.onsuccess = e => resolve(e.target.result || null);
       req.onerror = e => reject(e.target.error);
     });
-    _pricingCache = data;
+    _pricingCache = record ? record.data : null;
     _pricingLoaded = true;
-    return data;
+    return _pricingCache;
   } catch(e) {
     _pricingLoaded = true;
     _pricingCache = null;


### PR DESCRIPTION
## Summary
Refactored the IndexedDB pricing storage to use a shared database schema across multiple tools, enabling better data sharing and consistency.

## Key Changes
- **Database migration**: Changed from `fabricbom_pricing` (v1) to `toolbox_shared` (v2) database
- **Object store restructuring**: Replaced `pricing` object store with `datasets` object store using `key` as keyPath
- **Schema cleanup**: Added logic to delete and recreate the `datasets` object store on upgrade to ensure clean state
- **Data access pattern**: Updated pricing retrieval to:
  - Query `datasets` object store with key `'pricing'` instead of `'current'`
  - Extract data from nested `record.data` property instead of using the record directly
  - Improved null-safety with conditional data extraction
- **Applied to both files**: Changes made consistently across `custom-sku-bomgen-mobile.html` and `custom-sku-bomgen.html`

## Implementation Details
- The upgrade handler now safely deletes existing `datasets` stores before recreation to prevent conflicts
- Pricing data is now stored as a nested object with a `data` property, allowing for additional metadata storage
- Cache variable naming improved (`data` → `record`) for clarity on the data structure being handled

https://claude.ai/code/session_0148dhZcwwhYXjPLYzTEXiNz