### PR TITLE
Add Share Hyperlink feature to copy menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -552,6 +552,7 @@
 <!-- Copy/Export dropdown menu (position:fixed so it escapes overflow-y:auto parents) -->
 <div id="copy-menu">
   <div class="dm-section">Share</div>
+  <button class="dm-item" onclick="shareHyperlink()"><svg viewBox="0 0 13 13" fill="none"><path d="M5.5 7.5a3 3 0 0 0 4.243 0l1.5-1.5a3 3 0 0 0-4.243-4.243L6.25 2.5" stroke="currentColor" stroke-width="1.1" stroke-linecap="round"/><path d="M7.5 5.5a3 3 0 0 0-4.243 0L1.757 7a3 3 0 0 0 4.243 4.243L6.75 10.5" stroke="currentColor" stroke-width="1.1" stroke-linecap="round"/></svg>Share Hyperlink</button>
   <button class="dm-item" onclick="shareBOM()"><svg viewBox="0 0 13 13" fill="none"><circle cx="10" cy="2.5" r="1.5" stroke="currentColor" stroke-width="1.1"/><circle cx="10" cy="10.5" r="1.5" stroke="currentColor" stroke-width="1.1"/><circle cx="3" cy="6.5" r="1.5" stroke="currentColor" stroke-width="1.1"/><path d="M8.5 3.5L4.5 5.5M4.5 7.5L8.5 9.5" stroke="currentColor" stroke-width="1.1"/></svg>Share BOM URL</button>
   <div class="dm-sep"></div>
   <div class="dm-section">Copy to Clipboard</div>
@@ -1603,6 +1604,34 @@ function shareBOM() {
   const url = location.origin + location.pathname + '#bom=' + compressed;
   clipboardWrite(url, '✓ Share URL copied to clipboard');
   history.replaceState(null, '', '#bom=' + compressed);
+}
+
+function shareHyperlink() {
+  closeCopyMenu();
+  if (!cart.length) { toast('Nothing to share — add items first'); return; }
+  let compressed;
+  try {
+    compressed = LZString.compressToEncodedURIComponent(serializeBOM());
+  } catch(e) {
+    toast('Could not generate share URL: ' + e.message);
+    return;
+  }
+  const url = location.origin + location.pathname + '#bom=' + compressed;
+  const displayName = getMeta().cust;
+  const html = `<a href="${url}">${displayName.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;')}</a>`;
+  history.replaceState(null, '', '#bom=' + compressed);
+  if (navigator.clipboard && navigator.clipboard.write) {
+    const item = new ClipboardItem({
+      'text/html': new Blob([html], { type: 'text/html' }),
+      'text/plain': new Blob([url], { type: 'text/plain' })
+    });
+    navigator.clipboard.write([item]).then(
+      () => toast('✓ Hyperlink copied to clipboard'),
+      () => clipboardWrite(url, '✓ Share URL copied (hyperlink unavailable)')
+    );
+  } else {
+    clipboardWrite(url, '✓ Share URL copied (hyperlink unavailable)');
+  }
 }
 
 function exportCSV() {


### PR DESCRIPTION
## Summary
Added a new "Share Hyperlink" option to the copy/export menu that allows users to share their BOM as a formatted HTML hyperlink in addition to the plain URL.

## Key Changes
- Added "Share Hyperlink" button to the copy menu UI with a link icon SVG
- Implemented `shareHyperlink()` function that:
  - Validates that the cart has items before proceeding
  - Compresses the BOM data using LZString
  - Generates a shareable URL with the compressed BOM hash
  - Creates both HTML and plain text versions of the share content
  - Uses the Clipboard API to copy both formats when available, with fallback to plain text
  - Displays appropriate toast notifications for success or errors
  - Updates browser history with the BOM state

## Implementation Details
- The function properly escapes HTML entities in the display name to prevent injection issues
- Supports modern Clipboard API with `ClipboardItem` for copying multiple MIME types simultaneously
- Gracefully falls back to plain text copying if HTML clipboard writing is unavailable
- Reuses existing utility functions (`closeCopyMenu()`, `toast()`, `getMeta()`, `serializeBOM()`, `clipboardWrite()`)

https://claude.ai/code/session_01J26gCbD1qLesW4qWz9seqV