### PR TITLE
Add backup functionality for saved projects

### DIFF
--- a/index.html
+++ b/index.html
@@ -528,6 +528,7 @@
         <div class="lch">
           <svg width="13" height="13" viewBox="0 0 13 13" fill="none"><rect x="1" y="1" width="11" height="11" rx="1" stroke="#6B7589" stroke-width="1.1"/><rect x="4" y="1" width="5" height="4" rx=".5" stroke="#6B7589" stroke-width="1.1"/><rect x="3" y="7" width="7" height="4" rx=".5" stroke="#6B7589" stroke-width="1.1"/></svg>
           <h2>Saved Projects</h2>
+          <button class="btn bs" style="margin-left:auto;font-size:11px;padding:4px 10px;" onclick="backupProjects()" title="Download a Markdown backup of all saved projects"><svg viewBox="0 0 13 13" fill="none" style="width:12px;height:12px;"><path d="M6.5 1v8M3.5 6l3 3 3-3" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/><path d="M1 10v1a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1v-1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg>Backup All</button>
         </div>
         <div id="spv-filter-wrap">
           <input id="spv-filter" type="text" placeholder="Filter by project name, opportunity ID, or SE…" oninput="filterSavedProjects(this.value)" autocomplete="off" spellcheck="false">
@@ -1632,6 +1633,61 @@ function shareHyperlink() {
   } else {
     clipboardWrite(url, '✓ Share URL copied (hyperlink unavailable)');
   }
+}
+
+function backupProjects() {
+  if (!savedProjects.length) { toast('No saved projects to back up'); return; }
+
+  // Collect the most recent revision of each project (savedProjects is newest-first)
+  const seen = new Set();
+  const primaries = [];
+  savedProjects.forEach(p => {
+    const key = p.projectKey || p.id;
+    if (!seen.has(key)) { seen.add(key); primaries.push(p); }
+  });
+
+  const now = new Date();
+  const pad = n => String(n).padStart(2, '0');
+  const ts = `${now.getFullYear()}-${pad(now.getMonth()+1)}-${pad(now.getDate())}-${pad(now.getHours())}-${pad(now.getMinutes())}-${pad(now.getSeconds())}`;
+
+  const base = location.origin + location.pathname;
+
+  const lines = [`# FabricBOM backup ${ts}`, ''];
+  primaries.forEach(p => {
+    const m = p.meta || {};
+    const label = [m.cust, m.opp].filter(Boolean).join(' / ') || 'Untitled';
+    const saveDate = new Date(p.savedAt).toLocaleDateString('en-US', {month:'short', day:'numeric', year:'numeric'});
+    const displayName = `${label} - ${saveDate}`;
+    try {
+      const items = (p.cart || []).map(entry => {
+        if (entry._type === 'group') {
+          return { g: 1, l: entry.label, n: entry.note || '', sp: entry.showPricing ? 1 : 0 };
+        }
+        const rows = (entry.rows || []).map(r =>
+          r.section !== undefined
+            ? { s: r.section }
+            : [r.sku || '', r.desc || '', r.qty ?? null, r.kind || '', r.note || '', r._kindOverride || '']
+        );
+        return { p: entry.product, l: entry.label, r: rows };
+      });
+      const json = JSON.stringify({ v: 1, m: { c: m.cust||'', o: m.opp||'', e: m.eng||'', d: m.date||'', n: m.notes||'', t: m.term||'DD' }, i: items });
+      const compressed = LZString.compressToEncodedURIComponent(json);
+      const url = base + '#bom=' + compressed;
+      lines.push(`* [${displayName}](${url})`);
+    } catch(e) {
+      lines.push(`* ${displayName} *(URL generation failed)*`);
+    }
+  });
+  lines.push('');
+
+  const md = lines.join('\n');
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(new Blob([md], { type: 'text/markdown;charset=utf-8;' }));
+  a.download = `FabricBOM-Backup-${ts}.md`;
+  document.body.appendChild(a);
+  a.click();
+  setTimeout(() => { document.body.removeChild(a); URL.revokeObjectURL(a.href); }, 1000);
+  toast(`✓ Backup downloaded (${primaries.length} project${primaries.length !== 1 ? 's' : ''})`);
 }
 
 function exportCSV() {


### PR DESCRIPTION
## Summary
Added a "Backup All" button to the Saved Projects section that allows users to download a Markdown file containing links to all their saved projects.

## Key Changes
- Added "Backup All" button in the Saved Projects header with download icon
- Implemented `backupProjects()` function that:
  - Deduplicates projects by keeping only the most recent revision of each
  - Generates a timestamped Markdown file with clickable links to each project
  - Each link encodes the project data in the URL hash using LZString compression
  - Includes project metadata (customer, opportunity ID, save date) in the display name
  - Handles errors gracefully by noting failed URL generations
  - Triggers automatic download of the backup file
  - Shows a toast notification with the number of projects backed up

## Implementation Details
- Deduplication logic uses `projectKey` or `id` to identify unique projects
- Timestamp format: `YYYY-MM-DD-HH-MM-SS`
- Backup filename: `FabricBOM-Backup-{timestamp}.md`
- Each project link includes compressed JSON with version 1 format containing metadata and cart items
- Temporary DOM elements are cleaned up after download completes
- Graceful handling for empty project lists with user feedback

https://claude.ai/code/session_01G22wKo2W7a54Bp24n6jeuF