### PR TITLE
Add edit functionality for SKU groups and improve UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,8 +133,9 @@
   .bg-tag{font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:.05em;background:#EEF3FF;color:#3557A5;border:1px solid #B8CBF5;border-radius:2px;padding:1px 6px;}
   .bg-del{background:#FEF0EE;border:1px solid #F5C6C2;color:#C0392B;font-size:11px;font-weight:600;padding:3px 8px;border-radius:2px;cursor:pointer;font-family:inherit;margin-left:auto;}
   .bg-del:hover{background:#F5C6C2;}
-  .bg-edit{background:none;border:1px solid var(--c-ib);border-radius:2px;color:var(--c-text2);font-size:11px;font-weight:600;padding:3px 8px;cursor:pointer;font-family:inherit;transition:background .12s;}
+  .bg-edit{background:none;border:1px solid var(--c-ib);border-radius:2px;color:var(--c-text2);padding:4px 6px;cursor:pointer;display:inline-flex;align-items:center;transition:background .12s;}
   .bg-edit:hover{background:var(--c-sh);color:var(--c-text);}
+  .bg-edit svg{width:11px;height:11px;}
 
   /* BOM table */
   .bt-wrap{overflow-x:auto;-webkit-overflow-scrolling:touch;}
@@ -1197,7 +1198,7 @@ async function renderGroups() {
           </div>
           <div style="flex:1;min-width:0;"><input type="text" class="label-input bgp" value="${h(entry.label)}" onchange="updateEntryLabel(${entry.id},this.value)"><div class="bgm">${lines} line item${lines!==1?'s':''} · ${qty.toLocaleString()} units/licenses</div></div>
           ${entry.product !== 'Custom SKU' ? `<span class="bg-tag">${h(entry.product)}</span>` : ''}
-          <button class="bg-edit" onclick="openSkuModalForEdit(${entry.id})">Edit</button>
+          <button class="bg-edit" onclick="openSkuModalForEdit(${entry.id})" title="Edit rows"><svg viewBox="0 0 11 11" fill="none"><path d="M7.5 1.5l2 2L3 10H1V8L7.5 1.5z" stroke="currentColor" stroke-width="1.1" stroke-linejoin="round"/></svg></button>
           <button class="bg-del" onclick="removeFromCart(${entry.id})">✕</button>
         </div>
         <div class="bt-wrap"><table class="bt"><thead><tr>

--- a/index.html
+++ b/index.html
@@ -1196,7 +1196,8 @@ async function renderGroups() {
             <svg width="12" height="18" viewBox="0 0 12 18" fill="none"><circle cx="4" cy="4" r="1.3" fill="currentColor"/><circle cx="8" cy="4" r="1.3" fill="currentColor"/><circle cx="4" cy="9" r="1.3" fill="currentColor"/><circle cx="8" cy="9" r="1.3" fill="currentColor"/><circle cx="4" cy="14" r="1.3" fill="currentColor"/><circle cx="8" cy="14" r="1.3" fill="currentColor"/></svg>
           </div>
           <div style="flex:1;min-width:0;"><input type="text" class="label-input bgp" value="${h(entry.label)}" onchange="updateEntryLabel(${entry.id},this.value)"><div class="bgm">${lines} line item${lines!==1?'s':''} · ${qty.toLocaleString()} units/licenses</div></div>
-          ${entry.product === 'Custom SKU' ? `<button class="bg-edit" onclick="openSkuModalForEdit(${entry.id})">Edit</button>` : `<span class="bg-tag">${h(entry.product)}</span>`}
+          ${entry.product !== 'Custom SKU' ? `<span class="bg-tag">${h(entry.product)}</span>` : ''}
+          <button class="bg-edit" onclick="openSkuModalForEdit(${entry.id})">Edit</button>
           <button class="bg-del" onclick="removeFromCart(${entry.id})">✕</button>
         </div>
         <div class="bt-wrap"><table class="bt"><thead><tr>

--- a/index.html
+++ b/index.html
@@ -999,7 +999,7 @@ function updateEntryLabel(id, value) {
   const entry = cart.find(c => c.id === id);
   if (!entry) return;
   const v = value.trim();
-  if (v) entry.label = v;
+  entry.label = v;
   saveCart();
   markDirty();
   renderGroups();

--- a/index.html
+++ b/index.html
@@ -216,7 +216,8 @@
   .bgr-label{font-size:13px;font-weight:700;color:var(--c-text);flex:1;}
   .bgr-note{font-size:11px;color:var(--c-text2);font-style:italic;}
   .bgr-actions{display:flex;gap:5px;align-items:center;padding:0 10px;}
-  .bgr-btn{background:none;border:1px solid var(--c-ib);border-radius:2px;color:var(--c-text2);font-size:11px;font-weight:600;padding:3px 8px;cursor:pointer;font-family:inherit;transition:background .12s;}
+  .bgr-btn{background:none;border:1px solid var(--c-ib);border-radius:2px;color:var(--c-text2);font-size:11px;font-weight:600;padding:3px 8px;cursor:pointer;font-family:inherit;transition:background .12s;display:inline-flex;align-items:center;}
+  .bgr-btn svg{width:11px;height:11px;}
   .bgr-btn:hover{background:var(--c-sh);color:var(--c-text);}
   .bgr-btn.del{border-color:#F5C6C2;color:#C0392B;background:#FEF0EE;}
   .bgr-btn.del:hover{background:#F5C6C2;}
@@ -1147,7 +1148,7 @@ async function renderGroups() {
           ${groupPriceHtml}
         </div>
         <div class="bgr-actions">
-          <button class="bgr-btn" onclick="openEditGroup(${entry.id})">Edit</button>
+          <button class="bgr-btn" onclick="openEditGroup(${entry.id})" title="Edit group header"><svg viewBox="0 0 11 11" fill="none"><path d="M7.5 1.5l2 2L3 10H1V8L7.5 1.5z" stroke="currentColor" stroke-width="1.1" stroke-linejoin="round"/></svg></button>
           <button class="bgr-btn del" onclick="removeFromCart(${entry.id})">✕</button>
         </div>`;
       addDragListeners(el);

--- a/index.html
+++ b/index.html
@@ -133,6 +133,8 @@
   .bg-tag{font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:.05em;background:#EEF3FF;color:#3557A5;border:1px solid #B8CBF5;border-radius:2px;padding:1px 6px;}
   .bg-del{background:#FEF0EE;border:1px solid #F5C6C2;color:#C0392B;font-size:11px;font-weight:600;padding:3px 8px;border-radius:2px;cursor:pointer;font-family:inherit;margin-left:auto;}
   .bg-del:hover{background:#F5C6C2;}
+  .bg-edit{background:none;border:1px solid var(--c-ib);border-radius:2px;color:var(--c-text2);font-size:11px;font-weight:600;padding:3px 8px;cursor:pointer;font-family:inherit;transition:background .12s;}
+  .bg-edit:hover{background:var(--c-sh);color:var(--c-text);}
 
   /* BOM table */
   .bt-wrap{overflow-x:auto;-webkit-overflow-scrolling:touch;}
@@ -371,7 +373,7 @@
     #top-bar,#sidebar,#ch,.act-row,#toast,#pfw,#copy-menu,#project-menu,#add-menu{display:none!important;}
     #main{display:block;}
     #pbv{display:flex!important;overflow:visible;padding:20px;}
-    .bg-del,.bgr-actions{display:none!important;}
+    .bg-del,.bg-edit,.bgr-actions{display:none!important;}
     .lc,.bg{break-inside:avoid;}
     .pi-edit-btn,.pi-clear-btn{display:none!important;}
     #proj-info-card .pfg{display:none!important;}
@@ -920,18 +922,31 @@ function showAbout() {
 }
 
 // ── postMessage RECEIVER ─────────────────────────────────────────────────────
+let _skuEditId = null;
+
 window.addEventListener('message', e => {
   if (!e.data) return;
   if (e.data.type === 'FORTIBOM_CLOSE') { closeSkuModal(); return; }
   if (e.data.type !== 'FORTIBOM_ADD') return;
   const { product, label, rows, meta } = e.data;
-  cart.push({ id:++seq, product, label, rows, meta });
-  updateBadges();
-  renderGroups();
-  saveCart();
-  markDirty();
-  toast(`✓ Added to Project BOM: ${label}`);
-  if (cart.length === 1) showPBV();
+  if (_skuEditId !== null) {
+    const idx = cart.findIndex(c => c.id === _skuEditId);
+    if (idx !== -1) cart[idx] = { ...cart[idx], product, label, rows, meta };
+    _skuEditId = null;
+    closeSkuModal();
+    renderGroups();
+    saveCart();
+    markDirty();
+    toast(`✓ Updated: ${label || 'Custom SKU group'}`);
+  } else {
+    cart.push({ id:++seq, product, label, rows, meta });
+    updateBadges();
+    renderGroups();
+    saveCart();
+    markDirty();
+    toast(`✓ Added to Project BOM: ${label || 'Custom SKU group'}`);
+    if (cart.length === 1) showPBV();
+  }
 });
 
 // ── CART UI ──────────────────────────────────────────────────────────────────
@@ -1181,7 +1196,7 @@ async function renderGroups() {
             <svg width="12" height="18" viewBox="0 0 12 18" fill="none"><circle cx="4" cy="4" r="1.3" fill="currentColor"/><circle cx="8" cy="4" r="1.3" fill="currentColor"/><circle cx="4" cy="9" r="1.3" fill="currentColor"/><circle cx="8" cy="9" r="1.3" fill="currentColor"/><circle cx="4" cy="14" r="1.3" fill="currentColor"/><circle cx="8" cy="14" r="1.3" fill="currentColor"/></svg>
           </div>
           <div style="flex:1;min-width:0;"><input type="text" class="label-input bgp" value="${h(entry.label)}" onchange="updateEntryLabel(${entry.id},this.value)"><div class="bgm">${lines} line item${lines!==1?'s':''} · ${qty.toLocaleString()} units/licenses</div></div>
-          ${entry.product !== 'Custom SKU' ? `<span class="bg-tag">${h(entry.product)}</span>` : ''}
+          ${entry.product === 'Custom SKU' ? `<button class="bg-edit" onclick="openSkuModalForEdit(${entry.id})">Edit</button>` : `<span class="bg-tag">${h(entry.product)}</span>`}
           <button class="bg-del" onclick="removeFromCart(${entry.id})">✕</button>
         </div>
         <div class="bt-wrap"><table class="bt"><thead><tr>
@@ -1777,6 +1792,7 @@ function toggleAddMenu(e) {
 }
 function closeAddMenu() { document.getElementById('add-menu').classList.remove('on'); }
 function openSkuModal() {
+  _skuEditId = null;
   const frame = document.getElementById('sku-frame');
   if (!frame.src.includes('custom-sku-bomgen-mobile.html')) {
     frame.src = 'products/custom-sku-bomgen-mobile.html';
@@ -1785,7 +1801,24 @@ function openSkuModal() {
   }
   document.getElementById('sku-modal').classList.add('on');
 }
+function openSkuModalForEdit(entryId) {
+  const entry = cart.find(c => c.id === entryId);
+  if (!entry) return;
+  _skuEditId = entryId;
+  const frame = document.getElementById('sku-frame');
+  const doLoad = () => {
+    try { frame.contentWindow.loadForEdit({ label: entry.label, rows: entry.rows }); } catch(_) {}
+  };
+  if (!frame.src.includes('custom-sku-bomgen-mobile.html')) {
+    frame.src = 'products/custom-sku-bomgen-mobile.html';
+    frame.addEventListener('load', function onLoad() { frame.removeEventListener('load', onLoad); doLoad(); });
+  } else {
+    doLoad();
+  }
+  document.getElementById('sku-modal').classList.add('on');
+}
 function closeSkuModal() {
+  _skuEditId = null;
   document.getElementById('sku-modal').classList.remove('on');
 }
 document.getElementById('sku-modal').addEventListener('click', function(e) {

--- a/products/custom-sku-bomgen-mobile.html
+++ b/products/custom-sku-bomgen-mobile.html
@@ -215,7 +215,7 @@ textarea { resize: vertical; min-height: 68px; }
 input.sku-input {
   font-family: 'Courier New', monospace;
   font-size: 13px;
-  color: #1A4E82;
+  color: var(--forti-text);
   text-transform: uppercase;
   letter-spacing: .04em;
 }

--- a/products/custom-sku-bomgen-mobile.html
+++ b/products/custom-sku-bomgen-mobile.html
@@ -202,6 +202,10 @@ input.invalid, select.invalid, textarea.invalid {
   font-weight: 600;
 }
 textarea { resize: vertical; min-height: 68px; }
+#f-group-name::placeholder, #f-section-label::placeholder {
+  color: var(--forti-text-muted);
+  opacity: 0.55;
+}
 .hint-text {
   font-size: 11px;
   color: var(--forti-text-muted);
@@ -624,10 +628,9 @@ input.sku-input {
     </div>
     <div class="card-body">
       <div class="field">
-        <label>Group Name <span class="req">*</span></label>
+        <label>Group Name <span class="hint">(optional)</span></label>
         <input type="text" id="f-group-name" placeholder="e.g. FortiGate 91G — ENT Bundle"
                oninput="clearErr('f-group-name','err-group-name')">
-        <span class="field-err" id="err-group-name">Group name is required</span>
       </div>
       <div class="field">
         <label>Section Header Label <span class="hint">(dark divider row in BOM)</span></label>
@@ -696,8 +699,8 @@ input.sku-input {
   <button class="btn btn-primary" onclick="generateBOM()">
     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="display:inline-block;vertical-align:middle;margin-right:5px;margin-top:-1px;"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg><span class="btn-preview-label">Preview</span>
   </button>
-  <button class="btn btn-success" onclick="addToProjectBOM()">
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="display:inline-block;vertical-align:middle;margin-right:5px;margin-top:-1px;"><path d="M12 3v13M5 13l7 7 7-7"/><line x1="5" y1="21" x2="19" y2="21"/></svg>Add to BOM
+  <button id="add-to-bom-btn" class="btn btn-success" onclick="addToProjectBOM()">
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="display:inline-block;vertical-align:middle;margin-right:5px;margin-top:-1px;"><path d="M12 3v13M5 13l7 7 7-7"/><line x1="5" y1="21" x2="19" y2="21"/></svg><span id="add-to-bom-label">Add to BOM</span>
   </button>
   <span id="smsg"></span>
   <div class="action-spacer"></div>
@@ -730,6 +733,7 @@ let _rowIdCounter = 0;
 let _lastRows  = [];
 let _lastLabel = '';
 let _lastMeta  = {};
+let _isEditing = false;
 
 const KIND_OPTIONS = [
   { value: 'req',  label: 'REQ',  cls: 'selected-req'  },
@@ -1042,13 +1046,6 @@ function generateBOM() {
   const rows = [];
 
   const groupName = document.getElementById('f-group-name').value.trim();
-  if (!groupName) {
-    showErr('f-group-name','err-group-name');
-    document.getElementById('f-group-name').scrollIntoView({ behavior:'smooth', block:'center' });
-    valid = false;
-  } else {
-    clearErr('f-group-name','err-group-name');
-  }
 
   const skuRowEls = document.querySelectorAll('#sku-rows [data-row-type="sku"]');
   if (skuRowEls.length === 0) {
@@ -1157,7 +1154,7 @@ function addToProjectBOM() {
   }, '*');
 
   const msg = document.getElementById('smsg');
-  msg.textContent = `✓ "${_lastLabel}" added`;
+  msg.textContent = _isEditing ? `✓ "${_lastLabel || 'group'}" updated` : `✓ "${_lastLabel || 'group'}" added`;
   msg.className = '';
   msg.style.display = 'inline';
   setTimeout(() => { msg.style.display = 'none'; }, 4000);
@@ -1173,10 +1170,40 @@ function resetForm() {
   document.getElementById('bom-section').style.display = 'none';
   document.getElementById('smsg').style.display = 'none';
   document.getElementById('err-no-rows').style.display = 'none';
-  clearErr('f-group-name','err-group-name');
   _rowIdCounter = 0;
   _lastRows = [];
+  _isEditing = false;
+  const lbl = document.getElementById('add-to-bom-label');
+  if (lbl) lbl.textContent = 'Add to BOM';
   updateRowCountBadge();
+}
+
+// ─────────────────────────────────────────────
+//  loadForEdit — called by parent window to pre-populate for editing
+// ─────────────────────────────────────────────
+function loadForEdit(data) {
+  resetForm();
+  const { label, rows } = data;
+  document.getElementById('f-group-name').value = label || '';
+
+  let startIdx = 0;
+  if (rows.length > 0 && rows[0].section !== undefined) {
+    document.getElementById('f-section-label').value = rows[0].section;
+    startIdx = 1;
+  }
+
+  for (let i = startIdx; i < rows.length; i++) {
+    const r = rows[i];
+    if (r.section !== undefined) {
+      addSectionRow({ label: r.section });
+    } else {
+      addSkuRow({ sku: r.sku, desc: r.desc, qty: r.qty, kind: r.kind || 'req', note: r.note || '' });
+    }
+  }
+
+  _isEditing = true;
+  const lbl = document.getElementById('add-to-bom-label');
+  if (lbl) lbl.textContent = 'Update in BOM';
 }
 
 // ─────────────────────────────────────────────

--- a/products/custom-sku-bomgen-mobile.html
+++ b/products/custom-sku-bomgen-mobile.html
@@ -1197,7 +1197,7 @@ function loadForEdit(data) {
     if (r.section !== undefined) {
       addSectionRow({ label: r.section });
     } else {
-      addSkuRow({ sku: r.sku, desc: r.desc, qty: r.qty, kind: r.kind || 'req', note: r.note || '' });
+      addSkuRow({ sku: r.sku, desc: r.desc, qty: r.qty, kind: r._kindOverride !== undefined ? r._kindOverride : (r.kind || 'req'), note: r.note || '' });
     }
   }
 

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'fabricbom-v3.0.0.6';
+const CACHE = 'fabricbom-v3.0.0.6.1';
 
 const SHELL = [
   './',


### PR DESCRIPTION
## Summary
This PR adds the ability to edit existing SKU groups in the project BOM, along with UI improvements to support the edit workflow and better styling for form inputs.

## Key Changes

- **Edit SKU Groups**: Added `openSkuModalForEdit()` function to allow users to modify existing SKU group rows and metadata. The edit state is tracked via `_skuEditId` variable.
- **Edit Button UI**: 
  - Added `.bg-edit` button style with SVG icon for editing individual SKU rows
  - Updated `.bgr-btn` to support inline-flex layout with SVG icons
  - Added edit button to group header section with pencil icon
- **Form Improvements**:
  - Made "Group Name" field optional (removed required validation and error message)
  - Added placeholder styling for form inputs in custom SKU modal
  - Changed SKU input color to use CSS variable for consistency
  - Updated button label dynamically between "Add to BOM" and "Update in BOM"
- **Message Updates**: Toast messages now handle both add and edit operations with appropriate feedback
- **Print Styling**: Hidden edit buttons in print view alongside other action buttons
- **Cache Version**: Bumped service worker cache version to `v3.0.0.6.1`

## Implementation Details

- The `loadForEdit()` function in the custom SKU modal pre-populates form fields with existing data for editing
- The postMessage receiver now checks `_skuEditId` to determine whether to add a new entry or update an existing one
- Edit buttons use SVG icons (11x11px) for consistency with delete buttons
- Form validation was simplified by removing the group name requirement, allowing users to create unnamed groups

https://claude.ai/code/session_01WaEj8PVcmZbck7eWn7wEXR