### PR TITLE
Relocate BOM summary stats below BOM container

### DIFF
--- a/index.html
+++ b/index.html
@@ -501,12 +501,8 @@
         </div>
       </div>
 
-      <!-- Summary + Actions -->
+      <!-- Actions -->
       <div class="sbar" id="sbar">
-        <div class="si"><div class="sl">Product Groups</div><div class="sv" id="sum-g">0</div></div>
-        <div class="si hi"><div class="sl">Total Line Items</div><div class="sv" id="sum-l">0</div></div>
-        <div class="si"><div class="sl">Total Units / Licenses</div><div class="sv" id="sum-q">0</div></div>
-        <div class="si"><div class="sl">Term Applied</div><div class="sv" id="sum-term" style="font-size:14px;">-DD</div></div>
         <div class="act-row">
           <button class="btn bp" id="project-btn" onclick="toggleProjectMenu(event)"><svg viewBox="0 0 13 13" fill="none"><rect x="1" y="1" width="11" height="11" rx="1" stroke="currentColor" stroke-width="1.1"/><rect x="4" y="1" width="5" height="4" rx=".5" stroke="currentColor" stroke-width="1.1"/><rect x="3" y="7" width="7" height="4" rx=".5" stroke="currentColor" stroke-width="1.1"/></svg>Save / Export<svg viewBox="0 0 10 6" fill="none" style="width:9px;height:9px;margin-left:1px;"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
           <button class="btn bs" id="add-btn" onclick="toggleAddMenu(event)"><svg viewBox="0 0 13 13" fill="none"><rect x="1" y="4" width="11" height="5" rx="1" stroke="#6B7589" stroke-width="1.1"/><path d="M4 6.5h5M6.5 5.5v2" stroke="#6B7589" stroke-width="1.1" stroke-linecap="round"/></svg>Add<svg viewBox="0 0 10 6" fill="none" style="width:9px;height:9px;margin-left:1px;"><path d="M1 1l4 4 4-4" stroke="#6B7589" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
@@ -526,6 +522,14 @@
 
       <!-- BOM groups container -->
       <div id="bgc"></div>
+
+      <!-- BOM Summary Stats -->
+      <div class="sbar" id="bom-stats">
+        <div class="si"><div class="sl">Product Groups</div><div class="sv" id="sum-g">0</div></div>
+        <div class="si hi"><div class="sl">Total Line Items</div><div class="sv" id="sum-l">0</div></div>
+        <div class="si"><div class="sl">Total Units / Licenses</div><div class="sv" id="sum-q">0</div></div>
+        <div class="si"><div class="sl">Term Applied</div><div class="sv" id="sum-term" style="font-size:14px;">-DD</div></div>
+      </div>
 
       <!-- Project Total (only shown when pricing data is loaded) -->
       <div id="project-total" style="display:none;">


### PR DESCRIPTION
## Summary
Reorganized the layout of the summary statistics section by moving it from the top action bar to a dedicated position below the BOM groups container.

## Key Changes
- Removed summary statistics (Product Groups, Total Line Items, Total Units/Licenses, Term Applied) from the top action bar (`#sbar`)
- Created a new dedicated summary stats section (`#bom-stats`) positioned below the BOM groups container (`#bgc`)
- Updated the top action bar comment from "Summary + Actions" to "Actions" to reflect its new purpose
- Preserved all summary statistic elements and their IDs for continued functionality

## Implementation Details
- The summary statistics maintain their original HTML structure and styling classes (`si`, `sl`, `sv`)
- All element IDs remain unchanged (`sum-g`, `sum-l`, `sum-q`, `sum-term`), ensuring no JavaScript updates are required
- The new `#bom-stats` container uses the same `sbar` class styling for visual consistency
- This change improves the visual hierarchy by associating summary statistics directly with the BOM data they represent

https://claude.ai/code/session_01RcvXSfRdugKSyYeJkHaG93