### PR TITLE
Convert note input to textarea with improved styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,7 +152,7 @@
   .qty-input:focus{border-color:#4A90D9;outline:none;background:#fff;}
   .qty-input::-webkit-inner-spin-button,.qty-input::-webkit-outer-spin-button{opacity:0;}
   .qty-input:hover::-webkit-inner-spin-button,.qty-input:focus::-webkit-inner-spin-button{opacity:1;}
-  .note-input{width:100%;box-sizing:border-box;border:1px solid transparent;border-radius:3px;background:transparent;font-size:11px;color:var(--c-textm);font-family:inherit;padding:1px 3px;}
+  .note-input{width:100%;box-sizing:border-box;border:1px solid transparent;border-radius:3px;background:transparent;font-size:11px;color:var(--c-textm);font-family:inherit;padding:1px 3px;resize:none;overflow-y:auto;vertical-align:top;line-height:1.4;}
   .note-input:hover{border-color:var(--c-border);}
   .note-input:focus{border-color:#4A90D9;outline:none;background:#fff;}
   .nc{color:var(--c-textm);font-size:11px;}
@@ -1202,7 +1202,7 @@ async function renderGroups() {
         const detailTr = detailRows.length ? `<tr class="bom-detail"><td colspan="100"><table class="det-tbl"><tbody>${detailRows.join('')}</tbody></table></td></tr>` : '';
         const evenCls = lines%2===0 ? ' class="bt-even"' : '';
         const typeCell = `<button class="type-btn" onclick="openKindPopover(event,${entry.id},${i})" title="Click to change type">${bm[effectiveKind]||'<span class=\\"type-empty\\">—</span>'}<span class="type-hint">▾</span></button>`;
-        return `<tr${evenCls}>${expCell}<td><span class="sk">${h(r.sku||'')}</span></td><td class="nc col-desc"><span class="note-clamp" title="${h(r.desc||'')}">${h(r.desc||'')}</span></td><td class="qc"><input type="number" class="qty-input" value="${r.qty??''}" min="0" onchange="updateQty(${entry.id},${i},this.value)"></td><td class="col-type">${typeCell}</td><td class="nc col-notes"><input type="text" class="note-input" value="${h(r.note||'')}" placeholder="Add note…" onchange="updateNote(${entry.id},${i},this.value)" title="${h(r.note||'')}"></td>${priceCells}</tr>${detailTr}`;
+        return `<tr${evenCls}>${expCell}<td><span class="sk">${h(r.sku||'')}</span></td><td class="nc col-desc"><span class="note-clamp" title="${h(r.desc||'')}">${h(r.desc||'')}</span></td><td class="qc"><input type="number" class="qty-input" value="${r.qty??''}" min="0" onchange="updateQty(${entry.id},${i},this.value)"></td><td class="col-type">${typeCell}</td><td class="nc col-notes"><textarea class="note-input" rows="3" placeholder="Add note…" onchange="updateNote(${entry.id},${i},this.value)" title="${h(r.note||'')}">${h(r.note||'')}</textarea></td>${priceCells}</tr>${detailTr}`;
       }).join('');
       totL+=lines; totQ+=qty;
       const el = document.createElement('div');


### PR DESCRIPTION
## Summary
Converted the note input field from a single-line text input to a multi-line textarea element, with accompanying CSS improvements for better visual presentation and usability.

## Key Changes
- **HTML Structure**: Changed `.note-input` from `<input type="text">` to `<textarea rows="3">` to support multi-line note entry
- **CSS Enhancements**: Added styling properties to the `.note-input` class:
  - `resize: none` - Prevents user resizing of textarea
  - `overflow-y: auto` - Enables vertical scrolling when content exceeds visible area
  - `vertical-align: top` - Aligns textarea content to the top
  - `line-height: 1.4` - Improves readability with better line spacing
- **Content Handling**: Updated textarea to properly display existing note content using `${h(r.note||'')}` as inner text instead of value attribute

## Implementation Details
The textarea is configured with 3 rows by default, allowing users to enter multi-line notes while maintaining a compact table layout. The CSS changes ensure consistent appearance and prevent unwanted resize handles that could disrupt the table design. The overflow-y property allows graceful handling of content that exceeds the visible area.

https://claude.ai/code/session_01EJVDFJM2YFjM7hsMkVwiiU