### PR TITLE
Remove section header label input field from BOM generator

### DIFF
--- a/products/custom-sku-bomgen-mobile.html
+++ b/products/custom-sku-bomgen-mobile.html
@@ -202,7 +202,7 @@ input.invalid, select.invalid, textarea.invalid {
   font-weight: 600;
 }
 textarea { resize: vertical; min-height: 68px; }
-#f-group-name::placeholder, #f-section-label::placeholder {
+#f-group-name::placeholder {
   color: var(--forti-text-muted);
   opacity: 0.55;
 }
@@ -354,7 +354,6 @@ input.sku-input {
   font-family: inherit;
   font-size: 12px;
   font-weight: 700;
-  text-transform: uppercase;
   letter-spacing: .06em;
   color: var(--forti-text-secondary);
   flex: 1;
@@ -631,12 +630,6 @@ input.sku-input {
         <label>Group Name <span class="hint">(optional)</span></label>
         <input type="text" id="f-group-name" placeholder="e.g. FortiGate 91G — ENT Bundle"
                oninput="clearErr('f-group-name','err-group-name')">
-      </div>
-      <div class="field">
-        <label>Section Header Label <span class="hint">(dark divider row in BOM)</span></label>
-        <input type="text" id="f-section-label"
-               placeholder="e.g. Hardware + Enterprise Bundle — FortiGate 91G">
-        <span class="hint-text">Leave blank to omit the section header row.</span>
       </div>
     </div>
   </div>
@@ -1057,9 +1050,6 @@ function generateBOM() {
 
   if (!valid) return false;
 
-  const sectionLabel = document.getElementById('f-section-label').value.trim();
-  if (sectionLabel) rows.push({ section: sectionLabel });
-
   document.querySelectorAll('#sku-rows [data-row-id]').forEach(card => {
     const id   = card.dataset.rowId;
     const type = card.dataset.rowType;
@@ -1165,7 +1155,6 @@ function addToProjectBOM() {
 // ─────────────────────────────────────────────
 function resetForm() {
   document.getElementById('f-group-name').value = '';
-  document.getElementById('f-section-label').value = '';
   document.getElementById('sku-rows').innerHTML = '';
   document.getElementById('bom-section').style.display = 'none';
   document.getElementById('smsg').style.display = 'none';
@@ -1186,13 +1175,7 @@ function loadForEdit(data) {
   const { label, rows } = data;
   document.getElementById('f-group-name').value = label || '';
 
-  let startIdx = 0;
-  if (rows.length > 0 && rows[0].section !== undefined) {
-    document.getElementById('f-section-label').value = rows[0].section;
-    startIdx = 1;
-  }
-
-  for (let i = startIdx; i < rows.length; i++) {
+  for (let i = 0; i < rows.length; i++) {
     const r = rows[i];
     if (r.section !== undefined) {
       addSectionRow({ label: r.section });


### PR DESCRIPTION
## Summary
This PR removes the "Section Header Label" input field and its associated functionality from the custom SKU BOM generator form. The section header feature is being deprecated in favor of handling section rows directly through the data structure.

## Key Changes
- **Removed UI field**: Deleted the "Section Header Label" input field (`#f-section-label`) from the form, including its label, placeholder, and hint text
- **Removed CSS styling**: Eliminated the placeholder color styling rule for `#f-section-label`
- **Removed text-transform CSS**: Deleted the `text-transform: uppercase;` rule from the button/label styling (line 357)
- **Simplified form generation logic**: Removed code that checked for and added section labels as the first row in the BOM data
- **Updated form reset**: Removed the line that cleared the section label field value during form reset
- **Updated form loading**: Simplified the data loading logic to no longer check for section rows at index 0 and skip them; now processes all rows uniformly starting from index 0

## Implementation Details
The changes maintain backward compatibility with existing data structures that may contain section rows (identified by `section` property), but these are now handled as regular rows in the data array rather than being extracted from a dedicated form input. This simplifies the form UI while preserving the ability to work with section rows in the BOM data.

https://claude.ai/code/session_01GkGHvZS1QGgLi9FJ7AWvxJ