### PR TITLE
Rebrand CSV export/import to FabricBOM format (.fbom)

### DIFF
--- a/index.html
+++ b/index.html
@@ -391,6 +391,16 @@
   .save-dot.saved{display:inline-block;background:rgba(74,196,100,0.6);}
   .save-dot.dirty{display:inline-block;background:rgba(247,148,29,0.85);}
 
+  #pbv-watermark{margin-top:auto;padding:14px 4px 4px;text-align:center;font-size:11px;color:var(--c-textm);display:flex;align-items:center;justify-content:center;gap:6px;opacity:.75;}
+  #pbv-watermark a{display:inline-flex;align-items:center;gap:5px;color:inherit;text-decoration:none;font-weight:600;}
+  #pbv-watermark a:hover{color:var(--forti-red);}
+  #pbv-watermark .pbv-wm-logo{width:14px;height:14px;flex-shrink:0;}
+
+  @media print {
+    #pbv-watermark{margin-top:24px;opacity:1;color:#555;-webkit-print-color-adjust:exact;print-color-adjust:exact;}
+    #pbv-watermark a{color:#555;}
+  }
+
   @media print {
     body{background:#fff;overflow:auto;height:auto;}
     #top-bar,#sidebar,#ch,.act-row,#toast,#pfw,#copy-menu,#project-menu,#add-menu{display:none!important;}
@@ -566,6 +576,15 @@
         <span class="pt-label">Project Total</span>
         <span class="pt-value" id="pt-value"></span>
       </div>
+
+      <!-- Watermark -->
+      <div id="pbv-watermark">
+        Powered by
+        <a href="https://msalty.github.io/FabricBOM/" target="_blank" rel="noopener noreferrer">
+          <svg class="pbv-wm-logo" viewBox="0 0 28 28" fill="none" aria-hidden="true"><rect width="28" height="28" rx="4" fill="#EE3124"/><path d="M6 8h16v3H6zM6 12.5h10v3H6zM6 17h16v3H6z" fill="white"/></svg>
+          <span>FabricBOM</span>
+        </a>
+      </div>
     </div>
 
     <!-- Saved Projects view -->
@@ -629,8 +648,8 @@
   <button class="dm-item" onclick="saveProject();closeProjectMenu()"><svg viewBox="0 0 13 13" fill="none"><rect x="1" y="1" width="11" height="11" rx="1" stroke="currentColor" stroke-width="1.1"/><rect x="4" y="1" width="5" height="4" rx=".5" stroke="currentColor" stroke-width="1.1"/><rect x="3" y="7" width="7" height="4" rx=".5" stroke="currentColor" stroke-width="1.1"/></svg>Save Project</button>
   <div class="dm-sep"></div>
   <div class="dm-section">File</div>
-  <button class="dm-item" onclick="exportCSV();closeProjectMenu()"><svg viewBox="0 0 13 13" fill="none"><path d="M6.5 1v8M3.5 6l3 3 3-3" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/><path d="M1 10v1a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1v-1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg>Export CSV</button>
-  <button class="dm-item" onclick="openImport();closeProjectMenu()"><svg viewBox="0 0 13 13" fill="none"><path d="M6.5 9V1M9.5 6l-3 3-3-3" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/><path d="M1 10v1a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1v-1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg>Import CSV</button>
+  <button class="dm-item" onclick="exportCSV();closeProjectMenu()"><svg viewBox="0 0 13 13" fill="none"><path d="M6.5 1v8M3.5 6l3 3 3-3" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/><path d="M1 10v1a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1v-1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg>Export FabricBOM</button>
+  <button class="dm-item" onclick="openImport();closeProjectMenu()"><svg viewBox="0 0 13 13" fill="none"><path d="M6.5 9V1M9.5 6l-3 3-3-3" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/><path d="M1 10v1a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1v-1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg>Import FabricBOM</button>
   <div id="project-sfdc-section" style="display:none">
     <div class="dm-sep"></div>
     <div class="dm-section">SFDC Export (Download CSV)</div>
@@ -647,14 +666,14 @@
   <div id="imp-box">
     <h3>
       <svg width="14" height="14" viewBox="0 0 13 13" fill="none"><path d="M6.5 9V1M9.5 6l-3 3-3-3" stroke="#2A2F3A" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/><path d="M1 10v1a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1v-1" stroke="#2A2F3A" stroke-width="1.3" stroke-linecap="round"/></svg>
-      Import Project from CSV
+      Import Project from FabricBOM
     </h3>
     <div id="imp-body">
       <div id="imp-drop" onclick="document.getElementById('imp-file').click()" ondragover="impDragOver(event)" ondragleave="impDragLeave(event)" ondrop="impDrop(event)">
         <svg width="32" height="32" viewBox="0 0 32 32" fill="none" style="opacity:.35"><rect x="4" y="4" width="24" height="24" rx="3" stroke="#6B7589" stroke-width="1.5"/><path d="M10 16h12M16 10v12" stroke="#6B7589" stroke-width="1.5" stroke-linecap="round"/></svg>
-        <div style="font-weight:600;color:var(--c-text);margin-top:8px;">Drop a CSV file here or click to browse</div>
-        <p>Must be a FortiBOM-exported CSV. Project info and all product groups will be restored.</p>
-        <input type="file" id="imp-file" accept=".csv" style="display:none" onchange="impFileChosen(this)">
+        <div style="font-weight:600;color:var(--c-text);margin-top:8px;">Drop a .fbom file here or click to browse</div>
+        <p>Must be a FabricBOM-exported .fbom file. Project info and all product groups will be restored.</p>
+        <input type="file" id="imp-file" accept=".fbom" style="display:none" onchange="impFileChosen(this)">
       </div>
       <div id="imp-warn" style="display:none;font-size:12px;color:#8A5800;background:#FFF8EE;border:1px solid #F5D9A0;border-radius:3px;padding:8px 12px;"></div>
     </div>
@@ -1811,8 +1830,8 @@ function exportCSV() {
   const csv = rows.map(r=>r.map(c=>`"${String(c).replace(/"/g,'""')}"`).join(',')).join('\r\n');
   const a=document.createElement('a');
   a.href=URL.createObjectURL(new Blob([csv],{type:'text/csv;charset=utf-8;'}));
-  a.download=`FabricBOM_${p.cust.replace(/[^a-zA-Z0-9]/g,'_')}_${new Date().toISOString().slice(0,10)}.csv`;
-  a.click(); toast('✓ CSV exported');
+  a.download=`FabricBOM_${p.cust.replace(/[^a-zA-Z0-9]/g,'_')}_${new Date().toISOString().slice(0,10)}.fbom`;
+  a.click(); toast('✓ FabricBOM exported');
 }
 // ── COPY / EXPORT DROPDOWN ───────────────────────────────────────────────────
 function toggleCopyMenu(e) {

--- a/index.html
+++ b/index.html
@@ -671,7 +671,7 @@
     <div id="imp-body">
       <div id="imp-drop" onclick="document.getElementById('imp-file').click()" ondragover="impDragOver(event)" ondragleave="impDragLeave(event)" ondrop="impDrop(event)">
         <svg width="32" height="32" viewBox="0 0 32 32" fill="none" style="opacity:.35"><rect x="4" y="4" width="24" height="24" rx="3" stroke="#6B7589" stroke-width="1.5"/><path d="M10 16h12M16 10v12" stroke="#6B7589" stroke-width="1.5" stroke-linecap="round"/></svg>
-        <div style="font-weight:600;color:var(--c-text);margin-top:8px;">Drop a .fbom file here or click to browse</div>
+        <div style="font-weight:600;color:var(--c-text);margin-top:8px;">Drop an .fbom <span title="go ahead, drop it" aria-hidden="true">😉</span> … or click to browse.</div>
         <p>Must be a FabricBOM-exported .fbom file. Project info and all product groups will be restored.</p>
         <input type="file" id="imp-file" accept=".fbom" style="display:none" onchange="impFileChosen(this)">
       </div>


### PR DESCRIPTION
## Summary
This PR rebrands the project export/import functionality from generic CSV format to a FabricBOM-specific format (.fbom), and adds a watermark footer to the project view crediting FabricBOM.

## Key Changes
- **File format change**: Updated export/import to use `.fbom` extension instead of `.csv`
  - Export button label: "Export CSV" → "Export FabricBOM"
  - Import button label: "Import CSV" → "Import FabricBOM"
  - File input accept attribute: `.csv` → `.fbom`
  - Toast message: "CSV exported" → "FabricBOM exported"
  - Import dialog title: "Import Project from CSV" → "Import Project from FabricBOM"

- **Import UI improvements**:
  - Updated drop zone text to reference `.fbom` format with a playful emoji
  - Updated help text to specify "FabricBOM-exported .fbom file"

- **Added watermark footer**:
  - New `#pbv-watermark` section in the project view footer
  - Displays "Powered by FabricBOM" with clickable logo and link
  - Includes custom styling with hover effects and print-specific styling
  - Logo is an SVG with FabricBOM's red branding color
  - Print media query ensures watermark is visible and properly colored when printing

## Implementation Details
- The watermark uses flexbox layout with proper spacing and alignment
- Print styles include `print-color-adjust: exact` to preserve colors in printed output
- The watermark link opens in a new tab with security attributes (`rel="noopener noreferrer"`)
- SVG logo is marked as decorative with `aria-hidden="true"`

https://claude.ai/code/session_01Se5JyXoTAwmkLe59RJDh8W