### PR TITLE
Add project breadcrumb that displays when scrolled out of view

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,6 +80,11 @@
   .bci{font-size:12px;color:#6B7589;}
   .bcs{font-size:11px;color:#B0B8CC;}
   .bci.cur{color:#2A2F3A;font-weight:500;}
+  #bc-proj-sep,#bc-proj{display:none;}
+  #ch.has-proj #bc{color:#6B7589;font-weight:400;}
+  #ch.has-proj #bc-proj-sep{display:inline;}
+  #ch.has-proj #bc-proj{display:inline-block;max-width:min(50vw,420px);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;vertical-align:bottom;}
+  @media (max-width:600px){#ch.has-proj #bc-proj{max-width:40vw;}}
   #pfw{flex:1;overflow:hidden;display:flex;flex-direction:column;}
   #pf{border:none;width:100%;flex:1;}
   #ws{flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:16px;padding:40px;color:#6B7589;text-align:center;}
@@ -473,6 +478,8 @@
       <span class="bci">FabricBOM</span>
       <span class="bcs">›</span>
       <span class="bci cur" id="bc">Select a product</span>
+      <span class="bcs" id="bc-proj-sep">›</span>
+      <span class="bci cur" id="bc-proj"></span>
     </div>
 
     <!-- Product iframe area -->
@@ -2653,6 +2660,35 @@ initPiMode();
   document.getElementById(id).addEventListener('input', () => { savePiData(); if (cart.length) markDirty(); });
 });
 document.getElementById('pi-term').addEventListener('change', () => { savePiData(); if (cart.length) markDirty(); });
+
+// ── PROJECT BREADCRUMB (shows customer when Project Information scrolls behind #ch) ──
+function updateProjBreadcrumb() {
+  const ch   = document.getElementById('ch');
+  const pbv  = document.getElementById('pbv');
+  const card = document.getElementById('proj-info-card');
+  const cust = document.getElementById('pi-cust').value.trim();
+  const onPBV = pbv && pbv.style.display !== 'none';
+  let show = false;
+  if (onPBV && cust && card) {
+    show = card.getBoundingClientRect().bottom <= ch.getBoundingClientRect().bottom;
+  }
+  if (show) {
+    document.getElementById('bc-proj').textContent = cust;
+    ch.classList.add('has-proj');
+  } else {
+    ch.classList.remove('has-proj');
+  }
+}
+document.getElementById('pbv').addEventListener('scroll', updateProjBreadcrumb, {passive:true});
+document.getElementById('pi-cust').addEventListener('input', updateProjBreadcrumb);
+window.addEventListener('resize', updateProjBreadcrumb);
+updateProjBreadcrumb();
+['showPBV','loadProduct','showAbout'].forEach(fn => {
+  const orig = window[fn];
+  if (typeof orig === 'function') {
+    window[fn] = function(){ const r = orig.apply(this, arguments); updateProjBreadcrumb(); return r; };
+  }
+});
 
 // Ensure view mode content is populated before printing regardless of current state
 window.addEventListener('beforeprint', updatePiView);

--- a/index.html
+++ b/index.html
@@ -76,9 +76,9 @@
 
   /* CONTENT */
   #content{flex:1;background:var(--forti-content-bg);overflow:hidden;display:flex;flex-direction:column;min-height:0;}
-  #ch{height:40px;background:#fff;border-bottom:1px solid #DDE1E9;display:flex;align-items:center;padding:0 20px;gap:6px;flex-shrink:0;}
-  .bci{font-size:12px;color:#6B7589;}
-  .bcs{font-size:11px;color:#B0B8CC;}
+  #ch{height:40px;background:#fff;border-bottom:1px solid #DDE1E9;display:flex;align-items:center;padding:0 20px;gap:6px;flex-shrink:0;flex-wrap:nowrap;overflow:hidden;min-width:0;}
+  .bci{font-size:12px;color:#6B7589;white-space:nowrap;flex-shrink:0;}
+  .bcs{font-size:11px;color:#B0B8CC;flex-shrink:0;}
   .bci.cur{color:#2A2F3A;font-weight:500;}
   #bc-proj-sep,#bc-proj{display:none;}
   #ch.has-proj #bc{color:#6B7589;font-weight:400;}


### PR DESCRIPTION
## Summary
This PR adds a dynamic breadcrumb feature that displays the customer/project name in the header when the Project Information card scrolls out of view. This improves navigation context in the UI by keeping the current project visible at all times.

## Key Changes
- **Breadcrumb HTML**: Added two new elements (`#bc-proj-sep` and `#bc-proj`) to the header to display the project separator and customer name
- **Breadcrumb Styling**: 
  - Enhanced `#ch` (header) with `flex-wrap:nowrap`, `overflow:hidden`, and `min-width:0` to prevent wrapping
  - Added `white-space:nowrap` and `flex-shrink:0` to breadcrumb items (`.bci`, `.bcs`) for proper text handling
  - Styled `#bc-proj` with ellipsis overflow handling and responsive max-width (50vw on desktop, 40vw on mobile)
  - Hidden by default with conditional display via `has-proj` class
- **Dynamic Breadcrumb Logic**: 
  - Implemented `updateProjBreadcrumb()` function that monitors when the Project Information card scrolls behind the header
  - Automatically shows/hides the project breadcrumb based on card visibility
  - Listens to scroll, input, and resize events to keep breadcrumb state in sync
  - Wraps key functions (`showPBV`, `loadProduct`, `showAbout`) to trigger breadcrumb updates

## Implementation Details
- Uses `getBoundingClientRect()` to detect when the project info card is scrolled out of view
- Passive scroll listener for performance optimization
- Responsive design with media query for screens ≤600px width
- Gracefully handles cases where elements don't exist or project view is not active

https://claude.ai/code/session_016773jdoxh93nEkLuEtaxGX