### PR TITLE
Shorten BOM summary stat labels and hide stats when empty

### DIFF
--- a/index.html
+++ b/index.html
@@ -571,10 +571,10 @@
 
       <!-- BOM Summary Stats -->
       <div class="sbar" id="bom-stats">
-        <div class="si"><div class="sl">Product Groups</div><div class="sv" id="sum-g">0</div></div>
-        <div class="si hi"><div class="sl">Total Line Items</div><div class="sv" id="sum-l">0</div></div>
-        <div class="si"><div class="sl">Total Units / Licenses</div><div class="sv" id="sum-q">0</div></div>
-        <div class="si"><div class="sl">Term Applied</div><div class="sv" id="sum-term">-DD</div></div>
+        <div class="si"><div class="sl">Groups</div><div class="sv" id="sum-g">0</div></div>
+        <div class="si hi"><div class="sl">Line Items</div><div class="sv" id="sum-l">0</div></div>
+        <div class="si"><div class="sl">Units / Lic.</div><div class="sv" id="sum-q">0</div></div>
+        <div class="si"><div class="sl">Term</div><div class="sv" id="sum-term">-DD</div></div>
       </div>
 
       <!-- Project Total (only shown when pricing data is loaded) -->
@@ -1162,10 +1162,12 @@ async function renderGroups() {
   if (!cart.length) {
     c.innerHTML = '';
     ec.style.display = 'flex';
+    document.getElementById('bom-stats').style.display = 'none';
     document.getElementById('project-total').style.display = 'none';
     return;
   }
   ec.style.display = 'none';
+  document.getElementById('bom-stats').style.display = '';
   let totL=0, totQ=0;
   let grandTotal=0, grandTotalValid=false;
 


### PR DESCRIPTION
## Summary
This PR improves the UI/UX of the BOM summary statistics section by shortening verbose labels to save space and hiding the stats panel when the BOM is empty.

## Key Changes
- **Shortened stat labels** for better space efficiency:
  - "Product Groups" → "Groups"
  - "Total Line Items" → "Line Items"
  - "Total Units / Licenses" → "Units / Lic."
  - "Term Applied" → "Term"

- **Hide BOM stats when empty**: Added logic to hide the `bom-stats` element when the cart is empty, consistent with the existing behavior for the project total section
  - Stats panel is hidden when cart is empty
  - Stats panel is shown when cart has items

## Implementation Details
The changes maintain the same HTML structure and element IDs while improving the visual presentation. The visibility toggle uses the same pattern already established for the project-total element, ensuring consistent behavior across the UI.

https://claude.ai/code/session_01XMqFj7H62NdFSABEc1EzRL