### PR TITLE
Bump FabricBOM version to v1.0.1d

### DIFF
--- a/index.html
+++ b/index.html
@@ -1146,7 +1146,7 @@ function showAbout() {
   ws.style.display = 'flex';
   ws.innerHTML = `
     <svg class="wl" viewBox="0 0 56 56" fill="none"><rect width="56" height="56" rx="8" fill="#EE3124"/><path d="M12 16h32v6H12zM12 25h20v6H12zM12 34h32v6H12z" fill="white"/></svg>
-    <h2>FabricBOM v1.0.1c</h2>
+    <h2>FabricBOM v1.0.1d</h2>
     <p>Cross-product Bill of Materials generator for Fortinet deployments. Build BOMs per product, then combine them into a Project BOM.</p>
     <div class="hint" style="max-width:380px;text-align:left;">
       <strong style="color:#4A5168;display:block;margin-bottom:4px;">Disclaimer</strong>

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'fabricbom-v3.0.0.6.3.4';
+const CACHE = 'fabricbom-v1.0.1d';
 
 const SHELL = [
   './',


### PR DESCRIPTION
## Summary
Updates the FabricBOM application version from v1.0.1c to v1.0.1d across the codebase.

## Key Changes
- Updated version string in the about/splash screen from `v1.0.1c` to `v1.0.1d` in `index.html`
- Updated service worker cache identifier from `fabricbom-v3.0.0.6.3.4` to `fabricbom-v1.0.1d` in `sw.js` to align with the application version

## Implementation Details
The cache version update in the service worker will trigger a cache refresh on the next application load, ensuring users receive the latest assets for this release.

https://claude.ai/code/session_0115g3WxELJfy3nSLakxqVCG