### PR TITLE
Add attribution link to Fortinet icons source

### DIFF
--- a/index.html
+++ b/index.html
@@ -1211,7 +1211,8 @@ function showAbout() {
       <strong style="color:#4A5168;display:block;margin-bottom:4px;">Disclaimer</strong>
       FabricBOM is not an officially sanctioned Fortinet product. Always validate output against the official Fortinet product ordering guides.
     </div>
-    <a href="https://github.com/msalty/FabricBOM/issues" target="_blank" rel="noopener noreferrer" style="font-size:12px;color:var(--forti-red);text-decoration:none;">Report an issue on GitHub →</a>`;
+    <a href="https://github.com/msalty/FabricBOM/issues" target="_blank" rel="noopener noreferrer" style="font-size:12px;color:var(--forti-red);text-decoration:none;">Report an issue on GitHub →</a>
+    <span style="font-size:11px;color:var(--forti-text-muted);margin-top:6px;">Fortinet product icons sourced from <a href="https://icons.fortinet.com/" target="_blank" rel="noopener noreferrer" style="color:var(--forti-red);text-decoration:none;">icons.fortinet.com</a>.</span>`;
 }
 
 // ── postMessage RECEIVER ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Added an attribution notice in the footer that credits icons.fortinet.com as the source of Fortinet product icons used in FabricBOM.

## Changes
- Added a new span element with attribution text linking to icons.fortinet.com
- Styled the attribution with muted text color and appropriate spacing to match the existing footer design
- Maintains consistency with the disclaimer section above it

## Details
The attribution is displayed as a small, muted text line below the GitHub issue reporting link, providing proper credit to Fortinet for the product icons used throughout the application. The link opens in a new tab with security attributes (`target="_blank" rel="noopener noreferrer"`).

https://claude.ai/code/session_017GqXAHBSKYohewBZzbRxqv