### PR TITLE
Add Help & FAQ navigation link to sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -526,6 +526,10 @@
       <svg class="ni-icon" viewBox="0 0 18 18" fill="none"><circle cx="9" cy="9" r="7.5" stroke="#8A93A8" stroke-width="1.2"/><path d="M9 8v5M9 6.5v.5" stroke="#8A93A8" stroke-width="1.4" stroke-linecap="round"/></svg>
       <span class="ni-label">About</span>
     </div>
+    <a class="ni" href="docs/help-faq.html" target="_blank" rel="noopener" style="text-decoration:none;">
+      <svg class="ni-icon" viewBox="0 0 18 18" fill="none"><circle cx="9" cy="9" r="7.5" stroke="#8A93A8" stroke-width="1.2"/><path d="M9 10.5v-.4c0-.4.2-.7.6-.9.9-.4 1.4-1.6.6-2.6A2 2 0 0 0 7 8" stroke="#8A93A8" stroke-width="1.3" stroke-linecap="round"/><circle cx="9" cy="12.5" r=".75" fill="#8A93A8"/></svg>
+      <span class="ni-label">Help & FAQ</span>
+    </a>
   </nav>
 
   <div id="content">


### PR DESCRIPTION
## Summary
Added a new "Help & FAQ" navigation item to the sidebar that links to the help documentation page.

## Changes
- Added a new navigation link (`<a>` element) in the sidebar navigation menu
- Link points to `docs/help-faq.html` and opens in a new tab with `target="_blank"`
- Included appropriate security attributes (`rel="noopener"`)
- Styled with `text-decoration:none` to match existing navigation items
- Added a custom SVG icon (question mark in circle) matching the design of other navigation icons
- Added "Help & FAQ" label text using the standard `ni-label` class

## Implementation Details
- The new navigation item follows the same HTML structure and styling conventions as the existing "About" link
- Uses the same icon styling classes (`ni-icon`, `ni-label`) for consistency
- SVG icon features a question mark symbol appropriate for help/FAQ functionality

https://claude.ai/code/session_01LpuANikiJ93RCt1mdnXN4L