### PR TITLE
Update service worker cache version and add documentation assets

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'fabricbom-v1.0.1e.2';
+const CACHE = 'fabricbom-v1.0.1e.3';
 
 const SHELL = [
   './',
@@ -75,6 +75,10 @@ const SHELL = [
   './products/fortiswitch-bomgen.html',
   './products/fortiweb-bomgen.html',
   './products/placeholder-bomgen.html',
+  './docs/help-faq.html',
+  './docs/screenshots/fabricbom-screenshot-demobom.jpg',
+  './docs/screenshots/fabricbom-docs-adding_sku.gif',
+  './docs/screenshots/fabricbom-docs-saving_pricing.gif',
 ];
 
 self.addEventListener('install', event => {


### PR DESCRIPTION
## Summary
Updated the service worker cache configuration to include documentation assets and bumped the cache version to ensure proper cache invalidation.

## Key Changes
- Incremented service worker cache version from `v1.0.1e.2` to `v1.0.1e.3`
- Added documentation assets to the service worker shell cache:
  - `./docs/help-faq.html` - Help and FAQ documentation page
  - `./docs/screenshots/fabricbom-screenshot-demobom.jpg` - Demo BOM screenshot
  - `./docs/screenshots/fabricbom-docs-adding_sku.gif` - SKU addition guide animation
  - `./docs/screenshots/fabricbom-docs-saving_pricing.gif` - Pricing save guide animation

## Implementation Details
These documentation assets are now pre-cached during service worker installation, ensuring they are available offline and improving load performance for users accessing the help and documentation sections of the application.

https://claude.ai/code/session_01Rcz3gL4AhwpfkRuKg42SKc