### PR TITLE
Add walkthrough screenshot to BOM editing documentation

### DIFF
--- a/docs/help-faq.html
+++ b/docs/help-faq.html
@@ -539,6 +539,10 @@
             </div>
           </details>
 
+          <a class="media-thumb" href="javascript:void(0)" onclick="openLightbox('screenshots/fabricbom-docs-editing_bom_items.gif')" aria-label="View full-size walkthrough">
+            <img src="screenshots/fabricbom-docs-editing_bom_items.gif" alt="Walkthrough: editing items on a Project BOM" loading="lazy">
+          </a>
+
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
Added a visual walkthrough screenshot to the "Editing Items on a Project BOM" help documentation section to improve user guidance.

## Changes
- Added an interactive lightbox-enabled image link displaying a GIF walkthrough of the BOM item editing process
- Image includes proper accessibility attributes (aria-label) and lazy loading for performance
- Screenshot is positioned after the existing details section for logical flow in the documentation

## Implementation Details
- Uses the existing `openLightbox()` JavaScript function for full-size image viewing
- Image file: `screenshots/fabricbom-docs-editing_bom_items.gif`
- Implements lazy loading to optimize page load performance
- Maintains semantic HTML structure with descriptive alt text for accessibility

https://claude.ai/code/session_01SKikjMse2PtkU9fdnB9msf