### PR TITLE
Add pricing-only dataset search tool with conditional visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -934,6 +934,7 @@ const CATALOG = [
   { file:'fortisiem-bomgen.html', label:'FortiSIEM', cat:'Management' },
   { file: 'fortisoar-bomgen.html', label: 'FortiSOAR', cat: 'Management' },
   { file:'fortiflex-bomgen.html', label:'FortiFlex', cat:'Licensing' },
+  { file:'asku.html', label:'Pricing Dataset Search', cat:'Pricing', pricingOnly:true },
   { file:'custom-sku-bomgen.html', label:'Search & Custom Entry', cat:'Catalog Search' },
   //{ file:'placeholder-bomgen.html',  label:'Placeholder',    cat:'Demo' },
 ];
@@ -1128,7 +1129,11 @@ async function buildNav() {
   let any = false;
   for (const [cat, prods] of Object.entries(groups)) {
     const items = [];
-    for (const p of prods) { if (await exists(`products/${p.file}`)) { items.push(p); any=true; } }
+    for (const p of prods) {
+      if (!await exists(`products/${p.file}`)) continue;
+      if (p.pricingOnly) { const pd = await getPricingIDB(); if (!pd?.data?.rows?.length) continue; }
+      items.push(p); any=true;
+    }
     if (!items.length) continue;
     const lbl = document.createElement('div'); lbl.className='nsl'; lbl.textContent=cat; lbl.style.paddingTop='14px'; c.appendChild(lbl);
     for (const p of items) {


### PR DESCRIPTION
## Summary
This change introduces a new "Pricing Dataset Search" tool that is only displayed when pricing data is available in the IndexedDB. It also refactors the product filtering logic to support conditional visibility based on data availability.

## Key Changes
- Added new `asku.html` product entry with `pricingOnly: true` flag to the products list under the "Pricing" category
- Refactored the product filtering loop to:
  - Check for file existence first
  - Conditionally validate pricing data availability for products marked with `pricingOnly` flag
  - Only include products in the UI if all conditions are met
- The pricing-only tool will only appear in the navigation menu when pricing data rows are present in IndexedDB

## Implementation Details
- The new product uses a `pricingOnly` boolean flag to indicate it requires pricing data
- When building the product list, products with this flag trigger a `getPricingIDB()` call to verify data availability
- Products are skipped if pricing data is missing, preventing broken tool links
- The refactored loop improves readability by using early `continue` statements instead of nested conditionals

https://claude.ai/code/session_012eneV7MsA1MTytHhsGbq5t