### PR TITLE
Remove max-width constraint from app container

### DIFF
--- a/products/asku.html
+++ b/products/asku.html
@@ -13,7 +13,7 @@
   }
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
   body { font-family: 'Segoe UI','Helvetica Neue',Arial,sans-serif; background: var(--bg); color: var(--text); font-size: 13px; line-height: 1.5; padding: 20px; min-height: 100vh; }
-  #app { max-width: 1400px; margin: 0 auto; }
+  #app { width: 100%; }
 
   /* PAGE HEADER */
   .ph { background: var(--white); border: 1px solid var(--border); border-radius: 4px; padding: 14px 20px; margin-bottom: 14px; display: flex; align-items: center; gap: 14px; }


### PR DESCRIPTION
## Summary
Modified the `#app` container styling to use full viewport width instead of a constrained maximum width.

## Changes
- Changed `#app` max-width from `1400px` with centered margin to `width: 100%`
- This allows the app container to expand to fill the full available width rather than being limited to 1400px

## Details
The app container will now stretch across the entire viewport width. This change removes the previous centered layout constraint that limited the content to a maximum of 1400px. The body padding (20px) remains in place to maintain spacing from the viewport edges.

https://claude.ai/code/session_01RaCYEE5aoUTu2Qz52xN2cu