### PR TITLE
Add plugin filtering support to product search

### DIFF
--- a/index.html
+++ b/index.html
@@ -538,7 +538,7 @@
     <div class="n-sep" style="margin-top:8px;"></div>
     <div class="nsl">Products</div>
     <div class="nav-search-wrap">
-      <input id="nav-search-input" type="text" placeholder="Filter products…" oninput="filterNav(this.value)" autocomplete="off" spellcheck="false">
+      <input id="nav-search-input" type="text" placeholder="Filter products &amp; plugins…" oninput="filterNav(this.value)" autocomplete="off" spellcheck="false">
       <button id="nav-search-clear" onclick="clearNavSearch()" title="Clear">&times;</button>
     </div>
     <div id="nav-items"><div class="n-load">Scanning products…</div></div>
@@ -1388,6 +1388,21 @@ function filterNav(q) {
     while (sib && !sib.classList.contains('nsl')) { if (sib.style.display !== 'none') anyVisible = true; sib = sib.nextElementSibling; }
     lbl.style.display = anyVisible ? '' : 'none';
   });
+  const pluginContainer = document.getElementById('plugin-nav-items');
+  if (!pluginContainer) return;
+  pluginContainer.querySelectorAll('.ni').forEach(el => {
+    el.style.display = (!term || el.querySelector('.ni-label').textContent.toLowerCase().includes(term)) ? '' : 'none';
+  });
+  pluginContainer.querySelectorAll('.nsl').forEach(lbl => {
+    let sib = lbl.nextElementSibling, anyVisible = false;
+    while (sib && !sib.classList.contains('nsl')) { if (sib.style.display !== 'none') anyVisible = true; sib = sib.nextElementSibling; }
+    lbl.style.display = anyVisible ? '' : 'none';
+  });
+  const sep = pluginContainer.querySelector('.n-sep');
+  if (sep) {
+    const anyPluginVisible = [...pluginContainer.querySelectorAll('.ni')].some(el => el.style.display !== 'none');
+    sep.style.display = anyPluginVisible ? '' : 'none';
+  }
 }
 function clearNavSearch() { const i=document.getElementById('nav-search-input'); i.value=''; filterNav(''); i.focus(); }
 


### PR DESCRIPTION
## Summary
Extended the product search/filter functionality to include plugins, allowing users to filter both products and plugins from a single search input.

## Key Changes
- Updated the search input placeholder text from "Filter products…" to "Filter products & plugins…" to reflect the expanded functionality
- Enhanced the `filterNav()` function to filter plugin items in addition to product items:
  - Added filtering logic for plugin navigation items (`.ni` elements) within the `plugin-nav-items` container
  - Added section label (`.nsl`) visibility toggling for plugin sections based on whether any items are visible
  - Added logic to show/hide the separator (`.n-sep`) between products and plugins based on plugin visibility

## Implementation Details
- The plugin filtering mirrors the existing product filtering logic, maintaining consistency in behavior
- Section labels are hidden when all items in that section are filtered out
- The separator between products and plugins is dynamically hidden when no plugins match the search term
- Includes a safety check to return early if the plugin container doesn't exist

https://claude.ai/code/session_01TQEKKCH3gP3yftitDfz5nG