### PR TITLE
Bump service worker cache version to v1.0.3

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'fabricbom-v1.0.2';
+const CACHE = 'fabricbom-v1.0.3';
 
 const SHELL = [
   './',


### PR DESCRIPTION
## Summary
Updated the service worker cache version identifier to v1.0.3, which will trigger a cache refresh for all users on their next visit.

## Changes
- Updated `CACHE` constant in `sw.js` from `'fabricbom-v1.0.2'` to `'fabricbom-v1.0.3'`

## Details
This cache version bump ensures that users receive the latest version of cached assets. When the service worker detects a new cache version, it will invalidate the old cache and fetch fresh resources, preventing stale content from being served.

https://claude.ai/code/session_01YVpt3JPbNT67iuBa4kD49W