### PR TITLE
Make summary bar sticky with improved styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
 
   /* Summary bar */
   .sbar{background:var(--c-white);border:1px solid var(--c-border);border-radius:4px;padding:8px 14px;display:flex;align-items:center;flex-wrap:wrap;gap:10px;}
-  #sbar{position:sticky;top:0;z-index:10;box-shadow:0 4px 12px rgba(0,0,0,.12);background:#555E72;border-color:#555E72;}
+  #sbar{position:sticky;top:0;z-index:10;box-shadow:0 4px 12px rgba(0,0,0,.12);background:#EFEAF0;border-color:#EFEAF0;}
   .si .sl{font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--c-textm);}
   .si .sv{font-size:13px;font-weight:600;color:var(--c-text);}
   .si.hi .sv{color:var(--forti-red);}

--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
 
   /* Summary bar */
   .sbar{background:var(--c-white);border:1px solid var(--c-border);border-radius:4px;padding:8px 14px;display:flex;align-items:center;flex-wrap:wrap;gap:10px;}
-  #sbar{position:sticky;top:20px;z-index:10;box-shadow:0 4px 12px rgba(0,0,0,.12);}
+  #sbar{position:sticky;top:0;z-index:10;box-shadow:0 4px 12px rgba(0,0,0,.12);}
   .si .sl{font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--c-textm);}
   .si .sv{font-size:13px;font-weight:600;color:var(--c-text);}
   .si.hi .sv{color:var(--forti-red);}

--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
 
   /* Summary bar */
   .sbar{background:var(--c-white);border:1px solid var(--c-border);border-radius:4px;padding:8px 14px;display:flex;align-items:center;flex-wrap:wrap;gap:10px;}
-  #sbar{position:sticky;top:0;z-index:10;box-shadow:0 4px 12px rgba(0,0,0,.12);background:var(--forti-content-bg);border-color:#B8BECC;}
+  #sbar{position:sticky;top:0;z-index:10;box-shadow:0 4px 12px rgba(0,0,0,.12);background:var(--forti-content-bg);border-color:#B8BECC;border-left:3px solid var(--forti-red);}
   .si .sl{font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--c-textm);}
   .si .sv{font-size:13px;font-weight:600;color:var(--c-text);}
   .si.hi .sv{color:var(--forti-red);}

--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
 
   /* Summary bar */
   .sbar{background:var(--c-white);border:1px solid var(--c-border);border-radius:4px;padding:8px 14px;display:flex;align-items:center;flex-wrap:wrap;gap:10px;}
-  #sbar{position:sticky;top:0;z-index:10;box-shadow:0 4px 12px rgba(0,0,0,.12);}
+  #sbar{position:sticky;top:0;z-index:10;box-shadow:0 4px 12px rgba(0,0,0,.12);background:#555E72;border-color:#555E72;}
   .si .sl{font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--c-textm);}
   .si .sv{font-size:13px;font-weight:600;color:var(--c-text);}
   .si.hi .sv{color:var(--forti-red);}

--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
 
   /* Summary bar */
   .sbar{background:var(--c-white);border:1px solid var(--c-border);border-radius:4px;padding:8px 14px;display:flex;align-items:center;flex-wrap:wrap;gap:10px;}
-  #sbar{position:sticky;top:0;z-index:10;box-shadow:0 2px 8px rgba(0,0,0,.06);}
+  #sbar{position:sticky;top:20px;z-index:10;box-shadow:0 4px 12px rgba(0,0,0,.12);}
   .si .sl{font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--c-textm);}
   .si .sv{font-size:13px;font-weight:600;color:var(--c-text);}
   .si.hi .sv{color:var(--forti-red);}

--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
 
   /* Summary bar */
   .sbar{background:var(--c-white);border:1px solid var(--c-border);border-radius:4px;padding:8px 14px;display:flex;align-items:center;flex-wrap:wrap;gap:10px;}
-  #sbar{position:sticky;top:0;z-index:10;box-shadow:0 4px 12px rgba(0,0,0,.12);background:#EFEAF0;border-color:#EFEAF0;}
+  #sbar{position:sticky;top:0;z-index:10;box-shadow:0 4px 12px rgba(0,0,0,.12);background:var(--forti-content-bg);border-color:#B8BECC;}
   .si .sl{font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--c-textm);}
   .si .sv{font-size:13px;font-weight:600;color:var(--c-text);}
   .si.hi .sv{color:var(--forti-red);}

--- a/index.html
+++ b/index.html
@@ -115,6 +115,7 @@
 
   /* Summary bar */
   .sbar{background:var(--c-white);border:1px solid var(--c-border);border-radius:4px;padding:8px 14px;display:flex;align-items:center;flex-wrap:wrap;gap:10px;}
+  #sbar{position:sticky;top:0;z-index:10;box-shadow:0 2px 8px rgba(0,0,0,.06);}
   .si .sl{font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--c-textm);}
   .si .sv{font-size:13px;font-weight:600;color:var(--c-text);}
   .si.hi .sv{color:var(--forti-red);}

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'fabricbom-v1.0.3.2.2';
+const CACHE = 'fabricbom-v1.0.3.2.3';
 
 const SHELL = [
   './',

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'fabricbom-v1.0.3.2';
+const CACHE = 'fabricbom-v1.0.3.2.1';
 
 const SHELL = [
   './',

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'fabricbom-v1.0.3.2.1';
+const CACHE = 'fabricbom-v1.0.3.2.2';
 
 const SHELL = [
   './',


### PR DESCRIPTION
## Summary
This PR improves the summary bar UI by making it sticky at the top of the page and enhancing its visual styling to better match the application's design system.

## Key Changes
- Updated service worker cache version from `v1.0.3.2` to `v1.0.3.2.3` to invalidate cached assets
- Made the summary bar (`#sbar`) sticky positioned at the top of the viewport with `position: sticky; top: 0`
- Added `z-index: 10` to ensure the sticky bar appears above other content
- Enhanced visual styling with:
  - Box shadow (`0 4px 12px rgba(0,0,0,.12)`) for depth
  - Updated background color to use `--forti-content-bg` variable
  - Updated border color to `#B8BECC`
  - Added a 3px left border accent in `--forti-red` for visual emphasis

## Implementation Details
The sticky positioning allows the summary bar to remain visible while scrolling through the page content, improving accessibility to key information. The styling updates align with the Fortinet design system variables already in use throughout the application.

https://claude.ai/code/session_01PUrq2jRLg1BScvtQveuefv