### PR TITLE
Add tooltip showing project total excluding optional items

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,8 +243,11 @@
 
   /* Project Total */
   #project-total{background:var(--c-white);border:1px solid var(--c-border);border-radius:4px;padding:14px 20px;display:flex;justify-content:flex-end;align-items:center;gap:20px;}
-  #project-total .pt-label{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--c-text2);}
+  #project-total .pt-label{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--c-text2);position:relative;cursor:default;}
   #project-total .pt-value{font-size:22px;font-weight:700;color:var(--forti-red);}
+  #project-total .pt-label .pt-tooltip{display:none;position:absolute;bottom:calc(100% + 6px);right:0;white-space:nowrap;background:#333;color:#fff;font-size:11px;font-weight:500;letter-spacing:.02em;text-transform:none;padding:5px 9px;border-radius:4px;pointer-events:none;z-index:10;}
+  #project-total .pt-label .pt-tooltip::after{content:'';position:absolute;top:100%;right:10px;border:5px solid transparent;border-top-color:#333;}
+  #project-total .pt-label:hover .pt-tooltip{display:block;}
 
   /* Import modal */
   #imp-modal{display:none;position:fixed;inset:0;z-index:500;background:rgba(0,0,0,.55);align-items:center;justify-content:center;}
@@ -691,7 +694,7 @@
 
       <!-- Project Total (only shown when pricing data is loaded) -->
       <div id="project-total" style="display:none;">
-        <span class="pt-label">Project Total</span>
+        <span class="pt-label">Project Total<span class="pt-tooltip" id="pt-tooltip"></span></span>
         <span class="pt-value" id="pt-value"></span>
       </div>
 
@@ -1691,7 +1694,7 @@ async function renderGroups() {
   ec.style.display = 'none';
   document.getElementById('bom-stats').style.display = '';
   let totL=0, totQ=0;
-  let grandTotal=0, grandTotalValid=false;
+  let grandTotal=0, grandTotalValid=false, grandTotalExclOpt=0, hasOptional=false;
 
   // Pre-compute per-group pricing totals (items between each group header and the next)
   const groupTotals = {};
@@ -1764,6 +1767,8 @@ async function renderGroups() {
         if (hasPricing) {
           const totalNum = (!isNaN(listPriceNum) && typeof r.qty === 'number') ? listPriceNum * r.qty : NaN;
           if (!isExcluded && !isNaN(totalNum)) { grandTotal += totalNum; grandTotalValid = true; }
+          if (!isExcluded && !isNaN(totalNum) && effectiveKind !== 'opt') { grandTotalExclOpt += totalNum; }
+          if (!isExcluded && !isNaN(totalNum) && effectiveKind === 'opt') { hasOptional = true; }
           const totalDisplay = isExcluded ? '$0.00' : (!isNaN(totalNum) ? '$'+totalNum.toLocaleString('en-US',{minimumFractionDigits:2,maximumFractionDigits:2}) : '');
           const listPriceDisplay = !isNaN(listPriceNum) ? '$'+listPriceNum.toLocaleString('en-US',{minimumFractionDigits:2,maximumFractionDigits:2}) : (listPrice ? h(listPrice) : '');
           priceCells = `<td class="nc" style="text-align:right;white-space:nowrap;">${listPriceDisplay}</td><td class="nc" style="text-align:right;white-space:nowrap;">${totalDisplay}</td>`;
@@ -1812,6 +1817,12 @@ async function renderGroups() {
   const ptEl = document.getElementById('project-total');
   if (hasPricing && grandTotalValid) {
     document.getElementById('pt-value').textContent = '$' + grandTotal.toLocaleString('en-US', {minimumFractionDigits:2, maximumFractionDigits:2});
+    const tooltipEl = document.getElementById('pt-tooltip');
+    if (hasOptional) {
+      tooltipEl.textContent = 'Excluding Optional — $' + grandTotalExclOpt.toLocaleString('en-US', {minimumFractionDigits:2, maximumFractionDigits:2});
+    } else {
+      tooltipEl.textContent = '';
+    }
     ptEl.style.display = 'flex';
   } else {
     ptEl.style.display = 'none';

--- a/index.html
+++ b/index.html
@@ -225,10 +225,10 @@
   .sr .label-input{font-size:10px;font-weight:700;letter-spacing:.06em;color:var(--c-text2);width:100%;display:block;}
 
   /* BOM Group header rows (user-created section dividers) */
-  .bom-group-row{background:#D8DCE6;border:1px solid #B4BAC8;border-radius:4px;display:flex;align-items:stretch;gap:0;overflow:hidden;cursor:default;}
+  .bom-group-row{background:#D8DCE6;border:1px solid #B4BAC8;border-radius:4px;display:flex;align-items:stretch;gap:0;cursor:default;}
   .bom-group-row.dragging{opacity:.45;box-shadow:0 4px 18px rgba(0,0,0,.18);}
   .bom-group-row.drag-over{outline:2px dashed var(--forti-red);outline-offset:2px;}
-  .bgr-accent{width:4px;background:var(--forti-red);flex-shrink:0;}
+  .bgr-accent{width:4px;background:var(--forti-red);flex-shrink:0;border-radius:3px 0 0 3px;}
   .bgr-body{flex:1;padding:9px 14px;display:flex;align-items:center;gap:12px;}
   .bgr-icon{color:var(--forti-red);flex-shrink:0;}
   .bgr-label{font-size:13px;font-weight:700;color:var(--c-text);flex:1;}

--- a/index.html
+++ b/index.html
@@ -239,7 +239,10 @@
   .bgr-btn:hover{background:var(--c-sh);color:var(--c-text);}
   .bgr-btn.del{border-color:#F5C6C2;color:#C0392B;background:#FEF0EE;}
   .bgr-btn.del:hover{background:#F5C6C2;}
-  .bgr-price{font-size:12px;font-weight:700;color:var(--forti-red);background:#fff;border:1px solid var(--c-border);border-radius:3px;padding:2px 8px;white-space:nowrap;margin-left:4px;}
+  .bgr-price{font-size:12px;font-weight:700;color:var(--forti-red);background:#fff;border:1px solid var(--c-border);border-radius:3px;padding:2px 8px;white-space:nowrap;margin-left:4px;position:relative;cursor:default;}
+  .bgr-price .bgr-price-tooltip{display:none;position:absolute;bottom:calc(100% + 6px);right:0;white-space:nowrap;background:#333;color:#fff;font-size:11px;font-weight:500;letter-spacing:.02em;padding:5px 9px;border-radius:4px;pointer-events:none;z-index:10;}
+  .bgr-price .bgr-price-tooltip::after{content:'';position:absolute;top:100%;right:10px;border:5px solid transparent;border-top-color:#333;}
+  .bgr-price:hover .bgr-price-tooltip{display:block;}
 
   /* Project Total */
   #project-total{background:var(--c-white);border:1px solid var(--c-border);border-radius:4px;padding:14px 20px;display:flex;justify-content:flex-end;align-items:center;gap:20px;}
@@ -1699,11 +1702,11 @@ async function renderGroups() {
   // Pre-compute per-group pricing totals (items between each group header and the next)
   const groupTotals = {};
   if (hasPricing) {
-    let curGrpId = null, curTotal = 0, curValid = false;
+    let curGrpId = null, curTotal = 0, curValid = false, curExclOpt = 0, curHasOpt = false;
     for (const entry of cart) {
       if (entry._type === 'group') {
-        if (curGrpId !== null) groupTotals[curGrpId] = { total: curTotal, valid: curValid };
-        curGrpId = entry.id; curTotal = 0; curValid = false;
+        if (curGrpId !== null) groupTotals[curGrpId] = { total: curTotal, valid: curValid, exclOpt: curExclOpt, hasOpt: curHasOpt };
+        curGrpId = entry.id; curTotal = 0; curValid = false; curExclOpt = 0; curHasOpt = false;
       } else {
         for (const r of rowsWithTerm(entry.rows)) {
           if (r.section !== undefined) continue;
@@ -1713,10 +1716,12 @@ async function renderGroups() {
           const lpn = lp ? parseFloat(String(lp).replace(/[^0-9.]/g, '')) : NaN;
           const tot = (!isNaN(lpn) && typeof r.qty === 'number') ? lpn * r.qty : NaN;
           if (!isNaN(tot)) { curTotal += tot; curValid = true; }
+          if (!isNaN(tot) && ek !== 'opt') { curExclOpt += tot; }
+          if (!isNaN(tot) && ek === 'opt') { curHasOpt = true; }
         }
       }
     }
-    if (curGrpId !== null) groupTotals[curGrpId] = { total: curTotal, valid: curValid };
+    if (curGrpId !== null) groupTotals[curGrpId] = { total: curTotal, valid: curValid, exclOpt: curExclOpt, hasOpt: curHasOpt };
   }
 
   c.innerHTML = '';
@@ -1724,7 +1729,7 @@ async function renderGroups() {
     if (entry._type === 'group') {
       const gt = hasPricing && entry.showPricing ? groupTotals[entry.id] : null;
       const groupPriceHtml = (gt && gt.valid)
-        ? `<span class="bgr-price">$${gt.total.toLocaleString('en-US',{minimumFractionDigits:2,maximumFractionDigits:2})}</span>`
+        ? `<span class="bgr-price">$${gt.total.toLocaleString('en-US',{minimumFractionDigits:2,maximumFractionDigits:2})}${gt.hasOpt ? `<span class="bgr-price-tooltip">Excluding Optional — $${gt.exclOpt.toLocaleString('en-US',{minimumFractionDigits:2,maximumFractionDigits:2})}</span>` : ''}</span>`
         : '';
       const el = document.createElement('div');
       el.className = 'bom-group-row';


### PR DESCRIPTION
## Summary
This PR adds a tooltip to the "Project Total" label that displays the total cost excluding optional items when optional components are present in the bill of materials.

## Key Changes
- **Styling**: Added CSS for tooltip styling with hover activation on the project total label, including a small arrow pointer
- **HTML**: Added a nested `<span class="pt-tooltip">` element within the "Project Total" label
- **Logic**: 
  - Track two separate totals: `grandTotal` (all items) and `grandTotalExclOpt` (excluding optional items)
  - Added `hasOptional` flag to detect when optional items are present
  - Populate tooltip text only when optional items exist, showing the excluded total
  - Tooltip remains empty when no optional items are in the BOM

## Implementation Details
- The tooltip appears on hover with a dark background (#333) and white text
- A small CSS arrow (using `::after` pseudo-element) points downward from the tooltip to the label
- The tooltip uses `pointer-events:none` to avoid interfering with interactions
- Optional items are identified by checking if `effectiveKind === 'opt'`

https://claude.ai/code/session_01GVTWoZT2tGaDGxNB47ZG2E