### PR TITLE
Hide summary bar border when unpinned

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@
   /* Summary bar */
   .sbar{background:var(--c-white);border:1px solid var(--c-border);border-radius:4px;padding:8px 14px;display:flex;align-items:center;flex-wrap:wrap;gap:10px;}
   #sbar{position:sticky;top:0;z-index:10;box-shadow:0 4px 12px rgba(0,0,0,.12);background:var(--forti-content-bg);border-color:#B8BECC;border-left:3px solid var(--forti-red);}
-  #sbar.unpinned{position:static;box-shadow:none;}
+  #sbar.unpinned{position:static;box-shadow:none;border-color:transparent;}
   #pin-btn{background:none;border:none;cursor:pointer;padding:3px;border-radius:3px;color:var(--c-textm);display:inline-flex;align-items:center;flex-shrink:0;transition:color .12s,background .12s;line-height:1;}
   #pin-btn:hover{background:var(--c-sh);color:var(--c-text);}
   #pin-btn.pinned{color:var(--forti-red);}


### PR DESCRIPTION
## Summary
Updated the styling for the unpinned summary bar to hide its border, improving the visual appearance when the sticky summary bar is in its unpinned state.

## Changes
- Added `border-color:transparent;` to the `#sbar.unpinned` CSS rule to make the border invisible when the summary bar is unpinned
- This complements the existing `position:static;box-shadow:none;` properties that were already removing the sticky positioning and shadow effect

## Details
When the summary bar is unpinned, it transitions from a sticky positioned element with a visible border to a static element. This change ensures the border is also hidden during this state, creating a cleaner visual transition and preventing the border from appearing when the element is no longer sticky.

https://claude.ai/code/session_0121urPgp4KXuV4e3PNYSM8y