### PR TITLE
Add cache clearing and hard reload functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -936,6 +936,14 @@
               Restores only the options on this Settings page (license term, price rounding, BOM defaults, editor behavior) to their factory values. <strong>Your saved projects, active BOM, pricelist, and plugins are not touched.</strong> Use <em>Clear Everything</em> above for a full wipe.
             </div>
           </div>
+
+          <div style="border-top:1px solid var(--c-border);padding-top:14px;margin-top:14px;">
+            <div style="font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.05em;color:var(--c-text2);margin-bottom:8px;">Service Worker &amp; Cache</div>
+            <button class="btn bd" onclick="clearServiceWorkerAndReload()">Clear Cache &amp; Hard Reload</button>
+            <div style="font-size:11px;color:var(--c-textm);margin-top:6px;line-height:1.5;">
+              Unregisters the service worker, deletes all cached assets, and reloads the page from the network. Use this if you're seeing stale content after an update. <strong>Your saved data is not affected.</strong>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -3407,6 +3415,28 @@ async function clearScope(scope) {
   } catch(e) {
     toast('⚠ ' + e.message);
   }
+}
+
+async function clearServiceWorkerAndReload() {
+  if (!confirm('Clear cache and hard reload?\n\nThis will unregister the service worker and delete all cached assets, then reload the page from the network. Your saved projects, settings, pricelist, and plugins are NOT affected.')) return;
+  try {
+    if ('serviceWorker' in navigator) {
+      const regs = await navigator.serviceWorker.getRegistrations();
+      await Promise.all(regs.map(r => r.unregister()));
+    }
+    if (window.caches && caches.keys) {
+      const keys = await caches.keys();
+      await Promise.all(keys.map(k => caches.delete(k)));
+    }
+    toast('✓ Cache cleared — reloading…');
+  } catch(e) {
+    toast('⚠ ' + e.message);
+  }
+  setTimeout(() => {
+    const u = new URL(location.href);
+    u.searchParams.set('_cb', Date.now());
+    location.replace(u.toString());
+  }, 500);
 }
 
 function resetSettingsToDefaults() {


### PR DESCRIPTION
## Summary
Added a new "Clear Cache & Hard Reload" feature to the Settings page that allows users to unregister the service worker, delete all cached assets, and reload the page from the network.

## Key Changes
- **UI Addition**: New settings section in the Data settings area with a "Clear Cache & Hard Reload" button and explanatory text
- **New Function**: `clearServiceWorkerAndReload()` that:
  - Prompts user for confirmation with details about what will be cleared
  - Unregisters all active service workers
  - Deletes all cached assets from the Cache API
  - Reloads the page with a cache-busting query parameter (`_cb`)
  - Shows user feedback via toast notifications for success or errors
  - Preserves all user data (projects, settings, pricelist, plugins)

## Implementation Details
- Uses async/await pattern for service worker and cache operations
- Includes error handling with user-friendly toast messages
- Adds a 500ms delay before reload to allow toast notification to display
- Uses `location.replace()` with a timestamp query parameter to force a fresh network request
- Confirmation dialog clearly communicates what is and isn't affected by the operation

https://claude.ai/code/session_01Ty2Ywm9xVY1meNCM1uGVe1