### PR TITLE
Add group-level drag-and-drop reordering with drop sentinel

### DIFF
--- a/index.html
+++ b/index.html
@@ -1946,7 +1946,7 @@ function toggleGroupCollapse(ev, groupId) {
   const willCollapse = !collapsedGroups.has(groupId);
   if (willCollapse) collapsedGroups.add(groupId); else collapsedGroups.delete(groupId);
   let n = row.nextElementSibling;
-  while (n && !n.classList.contains('bom-group-row')) {
+  while (n && !n.classList.contains('bom-group-row') && !n.classList.contains('bom-drop-sentinel')) {
     n.style.display = willCollapse ? 'none' : '';
     n = n.nextElementSibling;
   }

--- a/index.html
+++ b/index.html
@@ -230,6 +230,8 @@
   .bom-group-row{background:#D8DCE6;border:1px solid #B4BAC8;border-radius:4px;display:flex;align-items:stretch;gap:0;cursor:default;}
   .bom-group-row.dragging{opacity:.45;box-shadow:0 4px 18px rgba(0,0,0,.18);}
   .bom-group-row.drag-over{outline:2px dashed var(--forti-red);outline-offset:2px;}
+  .bom-drop-sentinel{min-height:32px;border-radius:4px;transition:outline .1s;}
+  .bom-drop-sentinel.drag-over{outline:2px dashed var(--forti-red);outline-offset:2px;}
   .bgr-accent{width:4px;background:var(--forti-red);flex-shrink:0;border-radius:3px 0 0 3px;}
   .bgr-body{flex:1;min-width:0;padding:9px 0;display:flex;align-items:center;gap:8px;}
   .bom-group-row .drag-handle{padding:0 4px 0 4px;}
@@ -2248,11 +2250,19 @@ async function renderGroups() {
   } else {
     ptEl.style.display = 'none';
   }
+  if (!isReadOnly()) {
+    const sentinel = document.createElement('div');
+    sentinel.className = 'bom-drop-sentinel';
+    sentinel.dataset.id = SENTINEL_ID;
+    addDragListeners(sentinel);
+    c.appendChild(sentinel);
+  }
   if (isReadOnly()) applyReadOnlyToDOM();
 }
 
 // ── DRAG-TO-REORDER ──────────────────────────────────────────────────────────
 let dragSrcId = null;
+const SENTINEL_ID = 0; // drop-zone at end of list; no real cart entry ever has id 0
 
 // Returns [startIdx, endIdxExclusive] of a group's block in `cart`:
 // the header itself plus the contiguous run of non-group entries after it.
@@ -2265,10 +2275,30 @@ function _groupBlockRange(headerIdx) {
 function _doDrop(targetId) {
   if (dragSrcId === null || dragSrcId === targetId) return;
   const srcIdx = cart.findIndex(c => c.id === dragSrcId);
-  const tgtIdx = cart.findIndex(c => c.id === targetId);
-  if (srcIdx === -1 || tgtIdx === -1) return;
+  if (srcIdx === -1) return;
 
   const src = cart[srcIdx];
+
+  if (targetId === SENTINEL_ID) {
+    // Append dragged item/group to the very end of the list.
+    if (src._type === 'group') {
+      const [s, e] = _groupBlockRange(srcIdx);
+      const block = cart.splice(s, e - s);
+      cart.push(...block);
+    } else {
+      const [moved] = cart.splice(srcIdx, 1);
+      cart.push(moved);
+    }
+    dragSrcId = null;
+    renderGroups();
+    saveCart();
+    markDirty();
+    return;
+  }
+
+  const tgtIdx = cart.findIndex(c => c.id === targetId);
+  if (tgtIdx === -1) return;
+
   if (src._type === 'group') {
     const [s, e] = _groupBlockRange(srcIdx);
 

--- a/index.html
+++ b/index.html
@@ -2218,13 +2218,22 @@ async function renderGroups() {
       c.appendChild(el);
     }
   }
+  // Sentinel must be in the DOM before the collapsed-state loop so the loop can use it as a stop marker.
+  if (!isReadOnly()) {
+    const sentinel = document.createElement('div');
+    sentinel.className = 'bom-drop-sentinel';
+    sentinel.dataset.id = SENTINEL_ID;
+    addDragListeners(sentinel);
+    c.appendChild(sentinel);
+  }
   // Apply collapsed state: hide siblings under each collapsed group row up to the next group row.
+  // Stop at the sentinel too so it is never hidden by a collapsed last group.
   for (const row of c.children) {
     if (!row.classList.contains('bom-group-row')) continue;
     const gid = Number(row.dataset.id);
     if (!collapsedGroups.has(gid)) continue;
     let n = row.nextElementSibling;
-    while (n && !n.classList.contains('bom-group-row')) {
+    while (n && !n.classList.contains('bom-group-row') && !n.classList.contains('bom-drop-sentinel')) {
       n.style.display = 'none';
       n = n.nextElementSibling;
     }
@@ -2250,13 +2259,6 @@ async function renderGroups() {
     ptEl.style.display = 'flex';
   } else {
     ptEl.style.display = 'none';
-  }
-  if (!isReadOnly()) {
-    const sentinel = document.createElement('div');
-    sentinel.className = 'bom-drop-sentinel';
-    sentinel.dataset.id = SENTINEL_ID;
-    addDragListeners(sentinel);
-    c.appendChild(sentinel);
   }
   if (isReadOnly()) applyReadOnlyToDOM();
 }

--- a/index.html
+++ b/index.html
@@ -2317,12 +2317,16 @@ function _doDrop(targetId) {
     // No-op: dropping onto itself or onto an item inside its own block.
     if (tgtBlockStart === s) return;
 
-    const block = cart.slice(s, e);
-    cart.splice(s, e - s);
-    // Recompute insertion point after splice (target block shifted if it was after source block).
-    const insertAt = tgtBlockStart > s ? tgtBlockStart - (e - s) : tgtBlockStart;
-    // Group lands immediately before the target group's block.
-    cart.splice(insertAt, 0, ...block);
+    if (s < tgtBlockStart) {
+      // Dragging down: land after the target group's block.
+      const [, tgt_e] = _groupBlockRange(tgtBlockStart);
+      const block = cart.splice(s, e - s);
+      cart.splice(tgt_e - (e - s), 0, ...block);
+    } else {
+      // Dragging up: land before the target group's block.
+      const block = cart.splice(s, e - s);
+      cart.splice(tgtBlockStart, 0, ...block);
+    }
   } else {
     const [moved] = cart.splice(srcIdx, 1);
     cart.splice(tgtIdx, 0, moved);

--- a/index.html
+++ b/index.html
@@ -2254,20 +2254,53 @@ async function renderGroups() {
 // ── DRAG-TO-REORDER ──────────────────────────────────────────────────────────
 let dragSrcId = null;
 
+// Returns [startIdx, endIdxExclusive] of a group's block in `cart`:
+// the header itself plus the contiguous run of non-group entries after it.
+function _groupBlockRange(headerIdx) {
+  let end = headerIdx + 1;
+  while (end < cart.length && cart[end]._type !== 'group') end++;
+  return [headerIdx, end];
+}
+
 function _doDrop(targetId) {
   if (dragSrcId === null || dragSrcId === targetId) return;
   const srcIdx = cart.findIndex(c => c.id === dragSrcId);
   const tgtIdx = cart.findIndex(c => c.id === targetId);
   if (srcIdx === -1 || tgtIdx === -1) return;
-  const [moved] = cart.splice(srcIdx, 1);
-  cart.splice(tgtIdx, 0, moved);
-  // If a product was dropped into a collapsed section, auto-expand so it's visible.
-  if (!moved._type) {
-    const newIdx = cart.indexOf(moved);
-    for (let i = newIdx - 1; i >= 0; i--) {
-      if (cart[i]._type === 'group') {
-        if (collapsedGroups.has(cart[i].id)) collapsedGroups.delete(cart[i].id);
-        break;
+
+  const src = cart[srcIdx];
+  if (src._type === 'group') {
+    const [s, e] = _groupBlockRange(srcIdx);
+
+    // Find the target group's block start: walk backward from tgtIdx to its header (or 0).
+    let tgtBlockStart = tgtIdx;
+    if (cart[tgtIdx]._type !== 'group') {
+      tgtBlockStart = 0;
+      for (let i = tgtIdx - 1; i >= 0; i--) {
+        if (cart[i]._type === 'group') { tgtBlockStart = i; break; }
+      }
+    }
+
+    // No-op: dropping onto itself or onto an item inside its own block.
+    if (tgtBlockStart === s) return;
+
+    const block = cart.slice(s, e);
+    cart.splice(s, e - s);
+    // Recompute insertion point after splice (target block shifted if it was after source block).
+    const insertAt = tgtBlockStart > s ? tgtBlockStart - (e - s) : tgtBlockStart;
+    // Group lands immediately before the target group's block.
+    cart.splice(insertAt, 0, ...block);
+  } else {
+    const [moved] = cart.splice(srcIdx, 1);
+    cart.splice(tgtIdx, 0, moved);
+    // If a product was dropped into a collapsed section, auto-expand so it's visible.
+    if (!moved._type) {
+      const newIdx = cart.indexOf(moved);
+      for (let i = newIdx - 1; i >= 0; i--) {
+        if (cart[i]._type === 'group') {
+          if (collapsedGroups.has(cart[i].id)) collapsedGroups.delete(cart[i].id);
+          break;
+        }
       }
     }
   }

--- a/index.html
+++ b/index.html
@@ -232,6 +232,7 @@
   .bom-group-row.drag-over{outline:2px dashed var(--forti-red);outline-offset:2px;}
   .bom-drop-sentinel{min-height:32px;border-radius:4px;transition:outline .1s;}
   .bom-drop-sentinel.drag-over{outline:2px dashed var(--forti-red);outline-offset:2px;}
+  .bg.group-dragging{opacity:.45;}
   .bgr-accent{width:4px;background:var(--forti-red);flex-shrink:0;border-radius:3px 0 0 3px;}
   .bgr-body{flex:1;min-width:0;padding:9px 0;display:flex;align-items:center;gap:8px;}
   .bom-group-row .drag-handle{padding:0 4px 0 4px;}
@@ -2346,6 +2347,20 @@ function _topItem(node) {
   return (node && node.dataset.id) ? node : null;
 }
 
+// Fades the item rows belonging to a group header in/out while the header is being dragged.
+function _applyGroupBlockClass(headerId, add) {
+  const bgc = document.getElementById('bgc');
+  let inBlock = false;
+  for (const child of bgc.children) {
+    if (!inBlock) {
+      if (Number(child.dataset.id) === headerId) inBlock = true;
+      continue;
+    }
+    if (child.classList.contains('bom-group-row') || child.classList.contains('bom-drop-sentinel')) break;
+    child.classList.toggle('group-dragging', add);
+  }
+}
+
 function addDragListeners(el) {
   // ── Mouse / HTML5 drag ──
   el.addEventListener('mousedown', e => {
@@ -2356,11 +2371,15 @@ function addDragListeners(el) {
     if (!el.draggable || isReadOnly()) { e.preventDefault(); return; }
     dragSrcId = Number(el.dataset.id);
     el.classList.add('dragging');
+    if (el.classList.contains('bom-group-row')) _applyGroupBlockClass(dragSrcId, true);
     e.dataTransfer.effectAllowed = 'move';
   });
   el.addEventListener('dragend', () => {
     el.classList.remove('dragging');
-    document.querySelectorAll('#bgc > *').forEach(n => n.classList.remove('drag-over'));
+    document.querySelectorAll('#bgc > *').forEach(n => {
+      n.classList.remove('drag-over');
+      n.classList.remove('group-dragging');
+    });
   });
   el.addEventListener('dragover', e => {
     e.preventDefault();
@@ -2379,6 +2398,7 @@ function addDragListeners(el) {
     e.preventDefault();
     dragSrcId = Number(el.dataset.id);
     el.classList.add('dragging');
+    if (el.classList.contains('bom-group-row')) _applyGroupBlockClass(dragSrcId, true);
   }, { passive: false });
 
   el.addEventListener('touchmove', e => {
@@ -2401,7 +2421,10 @@ function addDragListeners(el) {
     el.style.pointerEvents = 'none';
     const under = document.elementFromPoint(t.clientX, t.clientY);
     el.style.pointerEvents = '';
-    document.querySelectorAll('#bgc > *').forEach(n => n.classList.remove('drag-over'));
+    document.querySelectorAll('#bgc > *').forEach(n => {
+      n.classList.remove('drag-over');
+      n.classList.remove('group-dragging');
+    });
     const targetEl = under && _topItem(under);
     if (targetEl) _doDrop(Number(targetEl.dataset.id));
     else dragSrcId = null;
@@ -2409,7 +2432,10 @@ function addDragListeners(el) {
 
   el.addEventListener('touchcancel', () => {
     el.classList.remove('dragging');
-    document.querySelectorAll('#bgc > *').forEach(n => n.classList.remove('drag-over'));
+    document.querySelectorAll('#bgc > *').forEach(n => {
+      n.classList.remove('drag-over');
+      n.classList.remove('group-dragging');
+    });
     dragSrcId = null;
   });
 }

--- a/index.html
+++ b/index.html
@@ -2385,7 +2385,7 @@ function addDragListeners(el) {
     e.preventDefault();
     e.dataTransfer.dropEffect = 'move';
     document.querySelectorAll('#bgc > *').forEach(n => n.classList.remove('drag-over'));
-    if (Number(el.dataset.id) !== dragSrcId) el.classList.add('drag-over');
+    if (Number(el.dataset.id) !== dragSrcId && !el.classList.contains('group-dragging')) el.classList.add('drag-over');
   });
   el.addEventListener('drop', e => {
     e.preventDefault();
@@ -2410,7 +2410,7 @@ function addDragListeners(el) {
     el.style.pointerEvents = '';
     const targetEl = under && _topItem(under);
     document.querySelectorAll('#bgc > *').forEach(n => n.classList.remove('drag-over'));
-    if (targetEl && Number(targetEl.dataset.id) !== dragSrcId) targetEl.classList.add('drag-over');
+    if (targetEl && Number(targetEl.dataset.id) !== dragSrcId && !targetEl.classList.contains('group-dragging')) targetEl.classList.add('drag-over');
   }, { passive: false });
 
   el.addEventListener('touchend', e => {


### PR DESCRIPTION
## Summary
This PR enhances the drag-and-drop functionality to support reordering entire groups (headers + their items) as atomic units, and adds a drop sentinel element at the end of the list to allow appending items/groups to the very end.

## Key Changes

- **Drop Sentinel**: Added a `bom-drop-sentinel` element at the end of the BOM list (when not read-only) that serves as a drop target for appending items/groups to the end. Uses a special `SENTINEL_ID` (0) to distinguish it from real cart entries.

- **Group Block Reordering**: Implemented `_groupBlockRange()` helper to identify the contiguous block of a group (header + all non-group items following it). When dragging a group header, the entire block is moved as a unit.

- **Enhanced Drop Logic**: Rewrote `_doDrop()` to handle:
  - Appending to the sentinel (end of list)
  - Moving group blocks with proper index calculations for both upward and downward drags
  - Preventing no-op drops (group onto itself or items within its own block)
  - Preserving existing product-level drop behavior with auto-expand of collapsed sections

- **Visual Feedback**: Added `group-dragging` CSS class and `_applyGroupBlockClass()` function to fade out item rows while their group header is being dragged, providing clear visual indication of what's being moved.

- **Collapse State Handling**: Updated collapse/expand logic to recognize the sentinel as a boundary marker, preventing it from being hidden by collapsed groups.

- **Drag Event Improvements**: Enhanced drag event handlers (both mouse and touch) to:
  - Apply/remove the `group-dragging` class when dragging group headers
  - Prevent drag-over highlighting on items within a dragging group's block
  - Properly clean up all drag-related classes on drag end/cancel

## Implementation Details

- The sentinel is created before the collapsed-state loop so it can serve as a stop marker
- Group block calculations account for the direction of the drag to correctly position the moved block
- Touch and mouse drag handlers are kept in sync for consistent behavior

https://claude.ai/code/session_01NvZaxv6G696wwMfZjmG4Rk