### PR TITLE
Support FABRICBOM_ADD message type in modal handler

### DIFF
--- a/index.html
+++ b/index.html
@@ -1871,7 +1871,7 @@ let _skuInsertGroupId = null;
 window.addEventListener('message', e => {
   if (!e.data) return;
   if (e.data.type === 'FORTIBOM_CLOSE') { closeSkuModal(); return; }
-  if (e.data.type !== 'FORTIBOM_ADD') return;
+  if (e.data.type !== 'FORTIBOM_ADD' && e.data.type !== 'FABRICBOM_ADD') return;
   const { product, label, rows, meta } = e.data;
   if (_skuEditId !== null) {
     const idx = cart.findIndex(c => c.id === _skuEditId);


### PR DESCRIPTION
## Summary
Extended the message event listener to handle a new `FABRICBOM_ADD` message type in addition to the existing `FORTIBOM_ADD` type, allowing the SKU modal to process fabric BOM additions.

## Changes
- Modified the message type validation logic to accept both `FORTIBOM_ADD` and `FABRICBOM_ADD` message types
- Updated the conditional check from a simple inequality to an AND condition that validates against both message types

## Implementation Details
The change allows the same SKU modal handling logic to process messages from two different BOM sources (FORTIBOM and FABRICBOM), enabling broader integration with multiple BOM systems while maintaining backward compatibility with existing FORTIBOM functionality.

https://claude.ai/code/session_01KPSdboFbo9H1jJsEK58k6R