### PR TITLE
Fix menu conflicts by closing other menus when opening one

### DIFF
--- a/index.html
+++ b/index.html
@@ -2367,6 +2367,8 @@ function toggleCopyMenu(e) {
   e.stopPropagation();
   const menu = document.getElementById('copy-menu');
   if (menu.classList.contains('on')) { menu.classList.remove('on'); return; }
+  closeProjectMenu();
+  closeAddMenu();
   const rect = e.currentTarget.getBoundingClientRect();
   menu.style.top  = (rect.bottom + 4) + 'px';
   menu.style.left = rect.left + 'px';
@@ -2377,6 +2379,8 @@ function toggleAddMenu(e) {
   e.stopPropagation();
   const menu = document.getElementById('add-menu');
   if (menu.classList.contains('on')) { menu.classList.remove('on'); return; }
+  closeCopyMenu();
+  closeProjectMenu();
   const rect = e.currentTarget.getBoundingClientRect();
   menu.style.top  = (rect.bottom + 4) + 'px';
   menu.style.left = rect.left + 'px';
@@ -2420,6 +2424,8 @@ async function toggleProjectMenu(e) {
   e.stopPropagation();
   const menu = document.getElementById('project-menu');
   if (menu.classList.contains('on')) { menu.classList.remove('on'); return; }
+  closeCopyMenu();
+  closeAddMenu();
   const btn = e.currentTarget;
   try {
     const pricing = await getPricingIDB();


### PR DESCRIPTION
## Summary
This change fixes a UI issue where multiple menus could be open simultaneously by ensuring that when one menu is opened, all other menus are properly closed first.

## Key Changes
- **Copy menu**: Now closes the project menu and add menu before opening
- **Add menu**: Now closes the copy menu and project menu before opening
- **Project menu**: Now closes the copy menu and add menu before opening

## Implementation Details
Each menu's click handler now calls the appropriate `close*Menu()` functions before displaying itself. This ensures only one menu can be visible at a time, preventing overlapping menus and improving the user experience. The pattern is consistent across all three menus (copy, add, and project).

https://claude.ai/code/session_01EeWHuU3Xn67ruapLKMgFZ3